### PR TITLE
Generate MLIR files for matmul tests.

### DIFF
--- a/matmul/README.md
+++ b/matmul/README.md
@@ -5,11 +5,11 @@ https://github.com/iree-org/iree/tree/main/tests/e2e/matmul.
 
 ## Prerequisites
 
-## Quickstart
-
 First ensure you have the prerequisites from
 https://iree.dev/building-from-source/getting-started/, including CMake, a
 compiler like clang, and Python.
+
+## Quickstart
 
 1. Get the IREE compiler tools, either from release packages or a source build:
 
@@ -68,3 +68,9 @@ compiler like clang, and Python.
     ```bash
     ctest --test-dir build/ -R iree-test-suites
     ```
+
+## Generating test cases
+
+```bash
+bash generate_tests.sh
+```

--- a/matmul/generate_tests.sh
+++ b/matmul/generate_tests.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# Copyright 2024 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+shapes=(
+  "small"
+  "large"
+  "gpu_large"
+  "gpu_large_aligned"
+)
+
+# lhs_rhs_type;accumulator_type
+type_combinations=(
+  "i8;i32"
+  "f32;f32"
+  "f16;f16"
+  "f16;f32"
+  "bf16;bf16"
+  "bf16;f32"
+  "f8E4M3FNUZ;f32"
+)
+
+for shape in ${shapes[@]}; do
+  for type_combination in ${type_combinations[@]}; do
+    IFS=";" read -r -a types <<< "${type_combination}"
+    lhs_rhs_type="${types[0]}"
+    acc_type="${types[1]}"
+    echo "Generating ${lhs_rhs_type}_${acc_type}_${shape}"
+
+    name="matmul_${lhs_rhs_type}_${acc_type}_${shape}"
+    python tests/generate_e2e_matmul_tests.py \
+      --output_matmul_mlir=tests/generated/${name}_matmul.mlir \
+      --output_calls_mlir=tests/generated/${name}_calls.mlir \
+      --lhs_rhs_type=${lhs_rhs_type} \
+      --acc_type=${acc_type} \
+      --shapes=${shape}
+  done
+done

--- a/matmul/tests/generate_e2e_matmul_tests.py
+++ b/matmul/tests/generate_e2e_matmul_tests.py
@@ -654,7 +654,7 @@ def generate_function(
         import_declaration = f"func.func private @module.{func_name}(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view"
         func_definition = func_definition + (
             f"func.func @{func_name}(%lhs: {lhs_tensor_type}, %rhs: {rhs_tensor_type}, %acc: {acc_tensor_type}) -> {acc_tensor_type} {{\n"
-            f"{compute}\n"
+            f"{compute}"
             f"  return %result: {acc_tensor_type}\n"
             f"}}\n"
         )

--- a/matmul/tests/generated/matmul_bf16_bf16_gpu_large_aligned_calls.mlir
+++ b/matmul/tests/generated/matmul_bf16_bf16_gpu_large_aligned_calls.mlir
@@ -1,0 +1,71 @@
+builtin.module @calls attributes {
+  
+} {
+
+func.func private @matmul_test.generate_random_matrix(%device: !hal.device, %dim0: i64, %dim1: i64, %element_type: i32, %seed: i32) -> !hal.buffer_view
+func.func private @matmul_test.check_matmul_results(%device: !hal.device, %m: i64, %k: i64, %n: i64, %transpose_rhs: i32, %lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view, %actual_result: !hal.buffer_view)
+
+func.func private @module.matmul_accumulate_512x128xbf16_times_128x512xbf16_into_512x512xbf16(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_512x128xbf16_times_128x512xbf16_into_512x512xbf16(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+
+func.func @matmul_accumulate_512x128xbf16_times_128x512xbf16_into_512x512xbf16_512_128_512_acc_0() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 512x128x512"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 512 : i64
+  %lhs_dim1 = arith.constant 128 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 2 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 128 : i64
+  %rhs_dim1 = arith.constant 512 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 3 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 512 : i64
+  %acc_dim1 = arith.constant 512 : i64
+  %acc_element_type = hal.element_type<bf16> : i32
+  %acc_seed = arith.constant 4 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 512 : i64
+  %acc_copy_dim1 = arith.constant 512 : i64
+  %acc_copy_element_type = hal.element_type<bf16> : i32
+  %acc_copy_seed = arith.constant 4 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_512x128xbf16_times_128x512xbf16_into_512x512xbf16(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 512 : i64
+  %k = arith.constant 128 : i64
+  %n = arith.constant 512 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_512x128xbf16_times_128x512xbf16_into_512x512xbf16_512_128_512_1() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 512x128x512"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 512 : i64
+  %lhs_dim1 = arith.constant 128 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 5 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 128 : i64
+  %rhs_dim1 = arith.constant 512 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 6 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_512x128xbf16_times_128x512xbf16_into_512x512xbf16(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 512 : i64
+  %k = arith.constant 128 : i64
+  %n = arith.constant 512 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+
+}

--- a/matmul/tests/generated/matmul_bf16_bf16_gpu_large_aligned_matmul.mlir
+++ b/matmul/tests/generated/matmul_bf16_bf16_gpu_large_aligned_matmul.mlir
@@ -1,0 +1,13 @@
+func.func @matmul_accumulate_512x128xbf16_times_128x512xbf16_into_512x512xbf16(%lhs: tensor<512x128xbf16>, %rhs: tensor<128x512xbf16>, %acc: tensor<512x512xbf16>) -> tensor<512x512xbf16> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<512x128xbf16>, tensor<128x512xbf16>) outs(%acc: tensor<512x512xbf16>) -> tensor<512x512xbf16>
+  return %result: tensor<512x512xbf16>
+}
+
+func.func @matmul_512x128xbf16_times_128x512xbf16_into_512x512xbf16(%lhs: tensor<512x128xbf16>, %rhs: tensor<128x512xbf16>) -> tensor<512x512xbf16> {
+  %init_acc = tensor.empty() : tensor<512x512xbf16>
+  %c0_acc_type = arith.constant 0.0: bf16
+  %acc = linalg.fill ins(%c0_acc_type : bf16) outs(%init_acc : tensor<512x512xbf16>) -> tensor<512x512xbf16>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<512x128xbf16>, tensor<128x512xbf16>) outs(%acc: tensor<512x512xbf16>) -> tensor<512x512xbf16>
+  return %result: tensor<512x512xbf16>
+}
+

--- a/matmul/tests/generated/matmul_bf16_bf16_gpu_large_calls.mlir
+++ b/matmul/tests/generated/matmul_bf16_bf16_gpu_large_calls.mlir
@@ -1,0 +1,270 @@
+builtin.module @calls attributes {
+  
+} {
+
+func.func private @matmul_test.generate_random_matrix(%device: !hal.device, %dim0: i64, %dim1: i64, %element_type: i32, %seed: i32) -> !hal.buffer_view
+func.func private @matmul_test.check_matmul_results(%device: !hal.device, %m: i64, %k: i64, %n: i64, %transpose_rhs: i32, %lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view, %actual_result: !hal.buffer_view)
+
+func.func private @module.matmul_457x330xbf16_times_330x512xbf16_into_457x512xbf16(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_457x330xbf16_times_330x514xbf16_into_457x514xbf16(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_438x330xbf16_times_330x514xbf16_into_438x514xbf16(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_540x332xbf16_times_332x516xbf16_into_540x516xbf16(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_1000x4xbf16_times_4x512xbf16_into_1000x512xbf16(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_4x1000xbf16_times_1000x512xbf16_into_4x512xbf16(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_512x1000xbf16_times_1000x4xbf16_into_512x4xbf16(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_512x128xbf16_times_128x500xbf16_into_512x500xbf16(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_457x160xbf16_times_160x512xbf16_into_457x512xbf16(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_512x330xbf16_times_330x512xbf16_into_512x512xbf16(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+
+func.func @matmul_457x330xbf16_times_330x512xbf16_into_457x512xbf16_457_330_512_0() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 457x330x512"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 457 : i64
+  %lhs_dim1 = arith.constant 330 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 2 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 330 : i64
+  %rhs_dim1 = arith.constant 512 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 3 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_457x330xbf16_times_330x512xbf16_into_457x512xbf16(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 457 : i64
+  %k = arith.constant 330 : i64
+  %n = arith.constant 512 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_457x330xbf16_times_330x514xbf16_into_457x514xbf16_457_330_514_1() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 457x330x514"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 457 : i64
+  %lhs_dim1 = arith.constant 330 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 4 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 330 : i64
+  %rhs_dim1 = arith.constant 514 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 5 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_457x330xbf16_times_330x514xbf16_into_457x514xbf16(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 457 : i64
+  %k = arith.constant 330 : i64
+  %n = arith.constant 514 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_438x330xbf16_times_330x514xbf16_into_438x514xbf16_438_330_514_2() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 438x330x514"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 438 : i64
+  %lhs_dim1 = arith.constant 330 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 6 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 330 : i64
+  %rhs_dim1 = arith.constant 514 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 7 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_438x330xbf16_times_330x514xbf16_into_438x514xbf16(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 438 : i64
+  %k = arith.constant 330 : i64
+  %n = arith.constant 514 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_540x332xbf16_times_332x516xbf16_into_540x516xbf16_540_332_516_3() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 540x332x516"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 540 : i64
+  %lhs_dim1 = arith.constant 332 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 8 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 332 : i64
+  %rhs_dim1 = arith.constant 516 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 9 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_540x332xbf16_times_332x516xbf16_into_540x516xbf16(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 540 : i64
+  %k = arith.constant 332 : i64
+  %n = arith.constant 516 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_1000x4xbf16_times_4x512xbf16_into_1000x512xbf16_1000_4_512_4() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1000x4x512"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1000 : i64
+  %lhs_dim1 = arith.constant 4 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 10 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 4 : i64
+  %rhs_dim1 = arith.constant 512 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 11 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_1000x4xbf16_times_4x512xbf16_into_1000x512xbf16(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1000 : i64
+  %k = arith.constant 4 : i64
+  %n = arith.constant 512 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_4x1000xbf16_times_1000x512xbf16_into_4x512xbf16_4_1000_512_5() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 4x1000x512"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 4 : i64
+  %lhs_dim1 = arith.constant 1000 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 12 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1000 : i64
+  %rhs_dim1 = arith.constant 512 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 13 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_4x1000xbf16_times_1000x512xbf16_into_4x512xbf16(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 4 : i64
+  %k = arith.constant 1000 : i64
+  %n = arith.constant 512 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_512x1000xbf16_times_1000x4xbf16_into_512x4xbf16_512_1000_4_6() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 512x1000x4"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 512 : i64
+  %lhs_dim1 = arith.constant 1000 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 14 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1000 : i64
+  %rhs_dim1 = arith.constant 4 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 15 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_512x1000xbf16_times_1000x4xbf16_into_512x4xbf16(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 512 : i64
+  %k = arith.constant 1000 : i64
+  %n = arith.constant 4 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_512x128xbf16_times_128x500xbf16_into_512x500xbf16_512_128_500_7() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 512x128x500"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 512 : i64
+  %lhs_dim1 = arith.constant 128 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 16 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 128 : i64
+  %rhs_dim1 = arith.constant 500 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 17 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_512x128xbf16_times_128x500xbf16_into_512x500xbf16(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 512 : i64
+  %k = arith.constant 128 : i64
+  %n = arith.constant 500 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_457x160xbf16_times_160x512xbf16_into_457x512xbf16_457_160_512_8() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 457x160x512"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 457 : i64
+  %lhs_dim1 = arith.constant 160 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 18 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 160 : i64
+  %rhs_dim1 = arith.constant 512 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 19 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_457x160xbf16_times_160x512xbf16_into_457x512xbf16(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 457 : i64
+  %k = arith.constant 160 : i64
+  %n = arith.constant 512 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_512x330xbf16_times_330x512xbf16_into_512x512xbf16_512_330_512_9() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 512x330x512"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 512 : i64
+  %lhs_dim1 = arith.constant 330 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 20 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 330 : i64
+  %rhs_dim1 = arith.constant 512 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 21 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_512x330xbf16_times_330x512xbf16_into_512x512xbf16(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 512 : i64
+  %k = arith.constant 330 : i64
+  %n = arith.constant 512 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+
+}

--- a/matmul/tests/generated/matmul_bf16_bf16_gpu_large_matmul.mlir
+++ b/matmul/tests/generated/matmul_bf16_bf16_gpu_large_matmul.mlir
@@ -1,0 +1,80 @@
+func.func @matmul_457x330xbf16_times_330x512xbf16_into_457x512xbf16(%lhs: tensor<457x330xbf16>, %rhs: tensor<330x512xbf16>) -> tensor<457x512xbf16> {
+  %init_acc = tensor.empty() : tensor<457x512xbf16>
+  %c0_acc_type = arith.constant 0.0: bf16
+  %acc = linalg.fill ins(%c0_acc_type : bf16) outs(%init_acc : tensor<457x512xbf16>) -> tensor<457x512xbf16>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<457x330xbf16>, tensor<330x512xbf16>) outs(%acc: tensor<457x512xbf16>) -> tensor<457x512xbf16>
+  return %result: tensor<457x512xbf16>
+}
+
+func.func @matmul_457x330xbf16_times_330x514xbf16_into_457x514xbf16(%lhs: tensor<457x330xbf16>, %rhs: tensor<330x514xbf16>) -> tensor<457x514xbf16> {
+  %init_acc = tensor.empty() : tensor<457x514xbf16>
+  %c0_acc_type = arith.constant 0.0: bf16
+  %acc = linalg.fill ins(%c0_acc_type : bf16) outs(%init_acc : tensor<457x514xbf16>) -> tensor<457x514xbf16>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<457x330xbf16>, tensor<330x514xbf16>) outs(%acc: tensor<457x514xbf16>) -> tensor<457x514xbf16>
+  return %result: tensor<457x514xbf16>
+}
+
+func.func @matmul_438x330xbf16_times_330x514xbf16_into_438x514xbf16(%lhs: tensor<438x330xbf16>, %rhs: tensor<330x514xbf16>) -> tensor<438x514xbf16> {
+  %init_acc = tensor.empty() : tensor<438x514xbf16>
+  %c0_acc_type = arith.constant 0.0: bf16
+  %acc = linalg.fill ins(%c0_acc_type : bf16) outs(%init_acc : tensor<438x514xbf16>) -> tensor<438x514xbf16>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<438x330xbf16>, tensor<330x514xbf16>) outs(%acc: tensor<438x514xbf16>) -> tensor<438x514xbf16>
+  return %result: tensor<438x514xbf16>
+}
+
+func.func @matmul_540x332xbf16_times_332x516xbf16_into_540x516xbf16(%lhs: tensor<540x332xbf16>, %rhs: tensor<332x516xbf16>) -> tensor<540x516xbf16> {
+  %init_acc = tensor.empty() : tensor<540x516xbf16>
+  %c0_acc_type = arith.constant 0.0: bf16
+  %acc = linalg.fill ins(%c0_acc_type : bf16) outs(%init_acc : tensor<540x516xbf16>) -> tensor<540x516xbf16>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<540x332xbf16>, tensor<332x516xbf16>) outs(%acc: tensor<540x516xbf16>) -> tensor<540x516xbf16>
+  return %result: tensor<540x516xbf16>
+}
+
+func.func @matmul_1000x4xbf16_times_4x512xbf16_into_1000x512xbf16(%lhs: tensor<1000x4xbf16>, %rhs: tensor<4x512xbf16>) -> tensor<1000x512xbf16> {
+  %init_acc = tensor.empty() : tensor<1000x512xbf16>
+  %c0_acc_type = arith.constant 0.0: bf16
+  %acc = linalg.fill ins(%c0_acc_type : bf16) outs(%init_acc : tensor<1000x512xbf16>) -> tensor<1000x512xbf16>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<1000x4xbf16>, tensor<4x512xbf16>) outs(%acc: tensor<1000x512xbf16>) -> tensor<1000x512xbf16>
+  return %result: tensor<1000x512xbf16>
+}
+
+func.func @matmul_4x1000xbf16_times_1000x512xbf16_into_4x512xbf16(%lhs: tensor<4x1000xbf16>, %rhs: tensor<1000x512xbf16>) -> tensor<4x512xbf16> {
+  %init_acc = tensor.empty() : tensor<4x512xbf16>
+  %c0_acc_type = arith.constant 0.0: bf16
+  %acc = linalg.fill ins(%c0_acc_type : bf16) outs(%init_acc : tensor<4x512xbf16>) -> tensor<4x512xbf16>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<4x1000xbf16>, tensor<1000x512xbf16>) outs(%acc: tensor<4x512xbf16>) -> tensor<4x512xbf16>
+  return %result: tensor<4x512xbf16>
+}
+
+func.func @matmul_512x1000xbf16_times_1000x4xbf16_into_512x4xbf16(%lhs: tensor<512x1000xbf16>, %rhs: tensor<1000x4xbf16>) -> tensor<512x4xbf16> {
+  %init_acc = tensor.empty() : tensor<512x4xbf16>
+  %c0_acc_type = arith.constant 0.0: bf16
+  %acc = linalg.fill ins(%c0_acc_type : bf16) outs(%init_acc : tensor<512x4xbf16>) -> tensor<512x4xbf16>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<512x1000xbf16>, tensor<1000x4xbf16>) outs(%acc: tensor<512x4xbf16>) -> tensor<512x4xbf16>
+  return %result: tensor<512x4xbf16>
+}
+
+func.func @matmul_512x128xbf16_times_128x500xbf16_into_512x500xbf16(%lhs: tensor<512x128xbf16>, %rhs: tensor<128x500xbf16>) -> tensor<512x500xbf16> {
+  %init_acc = tensor.empty() : tensor<512x500xbf16>
+  %c0_acc_type = arith.constant 0.0: bf16
+  %acc = linalg.fill ins(%c0_acc_type : bf16) outs(%init_acc : tensor<512x500xbf16>) -> tensor<512x500xbf16>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<512x128xbf16>, tensor<128x500xbf16>) outs(%acc: tensor<512x500xbf16>) -> tensor<512x500xbf16>
+  return %result: tensor<512x500xbf16>
+}
+
+func.func @matmul_457x160xbf16_times_160x512xbf16_into_457x512xbf16(%lhs: tensor<457x160xbf16>, %rhs: tensor<160x512xbf16>) -> tensor<457x512xbf16> {
+  %init_acc = tensor.empty() : tensor<457x512xbf16>
+  %c0_acc_type = arith.constant 0.0: bf16
+  %acc = linalg.fill ins(%c0_acc_type : bf16) outs(%init_acc : tensor<457x512xbf16>) -> tensor<457x512xbf16>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<457x160xbf16>, tensor<160x512xbf16>) outs(%acc: tensor<457x512xbf16>) -> tensor<457x512xbf16>
+  return %result: tensor<457x512xbf16>
+}
+
+func.func @matmul_512x330xbf16_times_330x512xbf16_into_512x512xbf16(%lhs: tensor<512x330xbf16>, %rhs: tensor<330x512xbf16>) -> tensor<512x512xbf16> {
+  %init_acc = tensor.empty() : tensor<512x512xbf16>
+  %c0_acc_type = arith.constant 0.0: bf16
+  %acc = linalg.fill ins(%c0_acc_type : bf16) outs(%init_acc : tensor<512x512xbf16>) -> tensor<512x512xbf16>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<512x330xbf16>, tensor<330x512xbf16>) outs(%acc: tensor<512x512xbf16>) -> tensor<512x512xbf16>
+  return %result: tensor<512x512xbf16>
+}
+

--- a/matmul/tests/generated/matmul_bf16_bf16_large_calls.mlir
+++ b/matmul/tests/generated/matmul_bf16_bf16_large_calls.mlir
@@ -1,0 +1,321 @@
+builtin.module @calls attributes {
+  
+} {
+
+func.func private @matmul_test.generate_random_matrix(%device: !hal.device, %dim0: i64, %dim1: i64, %element_type: i32, %seed: i32) -> !hal.buffer_view
+func.func private @matmul_test.check_matmul_results(%device: !hal.device, %m: i64, %k: i64, %n: i64, %transpose_rhs: i32, %lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view, %actual_result: !hal.buffer_view)
+
+func.func private @module.matmul_accumulate_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxbf16(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_123x456xbf16_times_456x789xbf16_into_123x789xbf16(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxbf16(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_654x321xbf16_times_321x234xbf16_into_654x234xbf16(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_1x1000xbf16_times_1000x1000xbf16_into_1x1000xbf16(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_1000x1000xbf16_times_1000x1xbf16_into_1000x1xbf16(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_1000x1000xbf16_times_1000x1xbf16_into_1000x1xbf16(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+
+func.func @matmul_accumulate_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxbf16_123_456_789_acc_0() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 123x456x789"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 123 : i64
+  %lhs_dim1 = arith.constant 456 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 2 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 456 : i64
+  %rhs_dim1 = arith.constant 789 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 3 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 123 : i64
+  %acc_dim1 = arith.constant 789 : i64
+  %acc_element_type = hal.element_type<bf16> : i32
+  %acc_seed = arith.constant 4 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 123 : i64
+  %acc_copy_dim1 = arith.constant 789 : i64
+  %acc_copy_element_type = hal.element_type<bf16> : i32
+  %acc_copy_seed = arith.constant 4 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxbf16(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 123 : i64
+  %k = arith.constant 456 : i64
+  %n = arith.constant 789 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_123x456xbf16_times_456x789xbf16_into_123x789xbf16_123_456_789_acc_1() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 123x456x789"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 123 : i64
+  %lhs_dim1 = arith.constant 456 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 5 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 456 : i64
+  %rhs_dim1 = arith.constant 789 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 6 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 123 : i64
+  %acc_dim1 = arith.constant 789 : i64
+  %acc_element_type = hal.element_type<bf16> : i32
+  %acc_seed = arith.constant 7 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 123 : i64
+  %acc_copy_dim1 = arith.constant 789 : i64
+  %acc_copy_element_type = hal.element_type<bf16> : i32
+  %acc_copy_seed = arith.constant 7 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_123x456xbf16_times_456x789xbf16_into_123x789xbf16(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 123 : i64
+  %k = arith.constant 456 : i64
+  %n = arith.constant 789 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxbf16_654_321_234_2() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 654x321x234"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 654 : i64
+  %lhs_dim1 = arith.constant 321 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 8 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 321 : i64
+  %rhs_dim1 = arith.constant 234 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 9 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxbf16(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 654 : i64
+  %k = arith.constant 321 : i64
+  %n = arith.constant 234 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_654x321xbf16_times_321x234xbf16_into_654x234xbf16_654_321_234_3() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 654x321x234"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 654 : i64
+  %lhs_dim1 = arith.constant 321 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 10 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 321 : i64
+  %rhs_dim1 = arith.constant 234 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 11 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_654x321xbf16_times_321x234xbf16_into_654x234xbf16(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 654 : i64
+  %k = arith.constant 321 : i64
+  %n = arith.constant 234 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxbf16_1_1000_1000_acc_4() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1x1000x1000"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1 : i64
+  %lhs_dim1 = arith.constant 1000 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 12 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1000 : i64
+  %rhs_dim1 = arith.constant 1000 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 13 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 1 : i64
+  %acc_dim1 = arith.constant 1000 : i64
+  %acc_element_type = hal.element_type<bf16> : i32
+  %acc_seed = arith.constant 14 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 1 : i64
+  %acc_copy_dim1 = arith.constant 1000 : i64
+  %acc_copy_element_type = hal.element_type<bf16> : i32
+  %acc_copy_seed = arith.constant 14 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxbf16(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1 : i64
+  %k = arith.constant 1000 : i64
+  %n = arith.constant 1000 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_1x1000xbf16_times_1000x1000xbf16_into_1x1000xbf16_1_1000_1000_acc_5() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1x1000x1000"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1 : i64
+  %lhs_dim1 = arith.constant 1000 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 15 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1000 : i64
+  %rhs_dim1 = arith.constant 1000 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 16 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 1 : i64
+  %acc_dim1 = arith.constant 1000 : i64
+  %acc_element_type = hal.element_type<bf16> : i32
+  %acc_seed = arith.constant 17 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 1 : i64
+  %acc_copy_dim1 = arith.constant 1000 : i64
+  %acc_copy_element_type = hal.element_type<bf16> : i32
+  %acc_copy_seed = arith.constant 17 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_1x1000xbf16_times_1000x1000xbf16_into_1x1000xbf16(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1 : i64
+  %k = arith.constant 1000 : i64
+  %n = arith.constant 1000 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxbf16_1000_1000_1_acc_6() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1000x1000x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1000 : i64
+  %lhs_dim1 = arith.constant 1000 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 18 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1000 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 19 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 1000 : i64
+  %acc_dim1 = arith.constant 1 : i64
+  %acc_element_type = hal.element_type<bf16> : i32
+  %acc_seed = arith.constant 20 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 1000 : i64
+  %acc_copy_dim1 = arith.constant 1 : i64
+  %acc_copy_element_type = hal.element_type<bf16> : i32
+  %acc_copy_seed = arith.constant 20 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxbf16(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1000 : i64
+  %k = arith.constant 1000 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_1000x1000xbf16_times_1000x1xbf16_into_1000x1xbf16_1000_1000_1_acc_7() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1000x1000x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1000 : i64
+  %lhs_dim1 = arith.constant 1000 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 21 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1000 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 22 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 1000 : i64
+  %acc_dim1 = arith.constant 1 : i64
+  %acc_element_type = hal.element_type<bf16> : i32
+  %acc_seed = arith.constant 23 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 1000 : i64
+  %acc_copy_dim1 = arith.constant 1 : i64
+  %acc_copy_element_type = hal.element_type<bf16> : i32
+  %acc_copy_seed = arith.constant 23 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_1000x1000xbf16_times_1000x1xbf16_into_1000x1xbf16(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1000 : i64
+  %k = arith.constant 1000 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxbf16_1000_1000_1_8() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1000x1000x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1000 : i64
+  %lhs_dim1 = arith.constant 1000 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 24 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1000 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 25 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxbf16(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1000 : i64
+  %k = arith.constant 1000 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_1000x1000xbf16_times_1000x1xbf16_into_1000x1xbf16_1000_1000_1_9() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1000x1000x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1000 : i64
+  %lhs_dim1 = arith.constant 1000 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 26 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1000 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 27 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_1000x1000xbf16_times_1000x1xbf16_into_1000x1xbf16(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1000 : i64
+  %k = arith.constant 1000 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+
+}

--- a/matmul/tests/generated/matmul_bf16_bf16_large_matmul.mlir
+++ b/matmul/tests/generated/matmul_bf16_bf16_large_matmul.mlir
@@ -1,0 +1,48 @@
+func.func @matmul_accumulate_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxbf16(%lhs: tensor<?x?xbf16>, %rhs: tensor<?x?xbf16>, %acc: tensor<?x?xbf16>) -> tensor<?x?xbf16> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<?x?xbf16>, tensor<?x?xbf16>) outs(%acc: tensor<?x?xbf16>) -> tensor<?x?xbf16>
+  return %result: tensor<?x?xbf16>
+}
+
+func.func @matmul_accumulate_123x456xbf16_times_456x789xbf16_into_123x789xbf16(%lhs: tensor<123x456xbf16>, %rhs: tensor<456x789xbf16>, %acc: tensor<123x789xbf16>) -> tensor<123x789xbf16> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<123x456xbf16>, tensor<456x789xbf16>) outs(%acc: tensor<123x789xbf16>) -> tensor<123x789xbf16>
+  return %result: tensor<123x789xbf16>
+}
+
+func.func @matmul_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxbf16(%lhs: tensor<?x?xbf16>, %rhs: tensor<?x?xbf16>) -> tensor<?x?xbf16> {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %acc_dim0 = tensor.dim %lhs, %c0 : tensor<?x?xbf16>
+  %acc_dim1 = tensor.dim %rhs, %c1 : tensor<?x?xbf16>
+  %init_acc = tensor.empty(%acc_dim0, %acc_dim1) : tensor<?x?xbf16>
+  %c0_acc_type = arith.constant 0.0: bf16
+  %acc = linalg.fill ins(%c0_acc_type : bf16) outs(%init_acc : tensor<?x?xbf16>) -> tensor<?x?xbf16>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<?x?xbf16>, tensor<?x?xbf16>) outs(%acc: tensor<?x?xbf16>) -> tensor<?x?xbf16>
+  return %result: tensor<?x?xbf16>
+}
+
+func.func @matmul_654x321xbf16_times_321x234xbf16_into_654x234xbf16(%lhs: tensor<654x321xbf16>, %rhs: tensor<321x234xbf16>) -> tensor<654x234xbf16> {
+  %init_acc = tensor.empty() : tensor<654x234xbf16>
+  %c0_acc_type = arith.constant 0.0: bf16
+  %acc = linalg.fill ins(%c0_acc_type : bf16) outs(%init_acc : tensor<654x234xbf16>) -> tensor<654x234xbf16>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<654x321xbf16>, tensor<321x234xbf16>) outs(%acc: tensor<654x234xbf16>) -> tensor<654x234xbf16>
+  return %result: tensor<654x234xbf16>
+}
+
+func.func @matmul_accumulate_1x1000xbf16_times_1000x1000xbf16_into_1x1000xbf16(%lhs: tensor<1x1000xbf16>, %rhs: tensor<1000x1000xbf16>, %acc: tensor<1x1000xbf16>) -> tensor<1x1000xbf16> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<1x1000xbf16>, tensor<1000x1000xbf16>) outs(%acc: tensor<1x1000xbf16>) -> tensor<1x1000xbf16>
+  return %result: tensor<1x1000xbf16>
+}
+
+func.func @matmul_accumulate_1000x1000xbf16_times_1000x1xbf16_into_1000x1xbf16(%lhs: tensor<1000x1000xbf16>, %rhs: tensor<1000x1xbf16>, %acc: tensor<1000x1xbf16>) -> tensor<1000x1xbf16> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<1000x1000xbf16>, tensor<1000x1xbf16>) outs(%acc: tensor<1000x1xbf16>) -> tensor<1000x1xbf16>
+  return %result: tensor<1000x1xbf16>
+}
+
+func.func @matmul_1000x1000xbf16_times_1000x1xbf16_into_1000x1xbf16(%lhs: tensor<1000x1000xbf16>, %rhs: tensor<1000x1xbf16>) -> tensor<1000x1xbf16> {
+  %init_acc = tensor.empty() : tensor<1000x1xbf16>
+  %c0_acc_type = arith.constant 0.0: bf16
+  %acc = linalg.fill ins(%c0_acc_type : bf16) outs(%init_acc : tensor<1000x1xbf16>) -> tensor<1000x1xbf16>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<1000x1000xbf16>, tensor<1000x1xbf16>) outs(%acc: tensor<1000x1xbf16>) -> tensor<1000x1xbf16>
+  return %result: tensor<1000x1xbf16>
+}
+

--- a/matmul/tests/generated/matmul_bf16_bf16_small_calls.mlir
+++ b/matmul/tests/generated/matmul_bf16_bf16_small_calls.mlir
@@ -1,0 +1,906 @@
+builtin.module @calls attributes {
+  
+} {
+
+func.func private @matmul_test.generate_random_matrix(%device: !hal.device, %dim0: i64, %dim1: i64, %element_type: i32, %seed: i32) -> !hal.buffer_view
+func.func private @matmul_test.check_matmul_results(%device: !hal.device, %m: i64, %k: i64, %n: i64, %transpose_rhs: i32, %lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view, %actual_result: !hal.buffer_view)
+
+func.func private @module.matmul_accumulate_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxbf16(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_1x1xbf16_times_1x1xbf16_into_1x1xbf16(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxbf16(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_1x1xbf16_times_1x1xbf16_into_1x1xbf16(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_2x2xbf16_times_2x2xbf16_into_2x2xbf16(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_4x4xbf16_times_4x4xbf16_into_4x4xbf16(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_8x8xbf16_times_8x8xbf16_into_8x8xbf16(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_9x9xbf16_times_9x9xbf16_into_9x9xbf16(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_6x13xbf16_times_13x3xbf16_into_6x3xbf16(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_15x37xbf16_times_37x7xbf16_into_15x7xbf16(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_81x19xbf16_times_19x41xbf16_into_81x41xbf16(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_1x10xbf16_times_10x10xbf16_into_1x10xbf16(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_1x10xbf16_times_10x10xbf16_into_1x10xbf16(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_10x1xbf16_times_1x10xbf16_into_10x10xbf16(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_10x10xbf16_times_10x1xbf16_into_10x1xbf16(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_10x10xbf16_times_10x1xbf16_into_10x1xbf16(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+
+func.func @matmul_accumulate_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxbf16_1_1_1_acc_0() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1x1x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1 : i64
+  %lhs_dim1 = arith.constant 1 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 2 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 3 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 1 : i64
+  %acc_dim1 = arith.constant 1 : i64
+  %acc_element_type = hal.element_type<bf16> : i32
+  %acc_seed = arith.constant 4 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 1 : i64
+  %acc_copy_dim1 = arith.constant 1 : i64
+  %acc_copy_element_type = hal.element_type<bf16> : i32
+  %acc_copy_seed = arith.constant 4 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxbf16(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1 : i64
+  %k = arith.constant 1 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_1x1xbf16_times_1x1xbf16_into_1x1xbf16_1_1_1_acc_1() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1x1x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1 : i64
+  %lhs_dim1 = arith.constant 1 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 5 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 6 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 1 : i64
+  %acc_dim1 = arith.constant 1 : i64
+  %acc_element_type = hal.element_type<bf16> : i32
+  %acc_seed = arith.constant 7 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 1 : i64
+  %acc_copy_dim1 = arith.constant 1 : i64
+  %acc_copy_element_type = hal.element_type<bf16> : i32
+  %acc_copy_seed = arith.constant 7 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_1x1xbf16_times_1x1xbf16_into_1x1xbf16(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1 : i64
+  %k = arith.constant 1 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxbf16_1_1_1_2() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1x1x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1 : i64
+  %lhs_dim1 = arith.constant 1 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 8 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 9 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxbf16(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1 : i64
+  %k = arith.constant 1 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_1x1xbf16_times_1x1xbf16_into_1x1xbf16_1_1_1_3() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1x1x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1 : i64
+  %lhs_dim1 = arith.constant 1 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 10 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 11 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_1x1xbf16_times_1x1xbf16_into_1x1xbf16(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1 : i64
+  %k = arith.constant 1 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxbf16_2_2_2_acc_4() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 2x2x2"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 2 : i64
+  %lhs_dim1 = arith.constant 2 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 12 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 2 : i64
+  %rhs_dim1 = arith.constant 2 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 13 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 2 : i64
+  %acc_dim1 = arith.constant 2 : i64
+  %acc_element_type = hal.element_type<bf16> : i32
+  %acc_seed = arith.constant 14 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 2 : i64
+  %acc_copy_dim1 = arith.constant 2 : i64
+  %acc_copy_element_type = hal.element_type<bf16> : i32
+  %acc_copy_seed = arith.constant 14 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxbf16(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 2 : i64
+  %k = arith.constant 2 : i64
+  %n = arith.constant 2 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_2x2xbf16_times_2x2xbf16_into_2x2xbf16_2_2_2_acc_5() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 2x2x2"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 2 : i64
+  %lhs_dim1 = arith.constant 2 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 15 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 2 : i64
+  %rhs_dim1 = arith.constant 2 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 16 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 2 : i64
+  %acc_dim1 = arith.constant 2 : i64
+  %acc_element_type = hal.element_type<bf16> : i32
+  %acc_seed = arith.constant 17 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 2 : i64
+  %acc_copy_dim1 = arith.constant 2 : i64
+  %acc_copy_element_type = hal.element_type<bf16> : i32
+  %acc_copy_seed = arith.constant 17 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_2x2xbf16_times_2x2xbf16_into_2x2xbf16(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 2 : i64
+  %k = arith.constant 2 : i64
+  %n = arith.constant 2 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxbf16_4_4_4_acc_6() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 4x4x4"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 4 : i64
+  %lhs_dim1 = arith.constant 4 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 18 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 4 : i64
+  %rhs_dim1 = arith.constant 4 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 19 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 4 : i64
+  %acc_dim1 = arith.constant 4 : i64
+  %acc_element_type = hal.element_type<bf16> : i32
+  %acc_seed = arith.constant 20 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 4 : i64
+  %acc_copy_dim1 = arith.constant 4 : i64
+  %acc_copy_element_type = hal.element_type<bf16> : i32
+  %acc_copy_seed = arith.constant 20 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxbf16(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 4 : i64
+  %k = arith.constant 4 : i64
+  %n = arith.constant 4 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_4x4xbf16_times_4x4xbf16_into_4x4xbf16_4_4_4_acc_7() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 4x4x4"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 4 : i64
+  %lhs_dim1 = arith.constant 4 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 21 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 4 : i64
+  %rhs_dim1 = arith.constant 4 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 22 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 4 : i64
+  %acc_dim1 = arith.constant 4 : i64
+  %acc_element_type = hal.element_type<bf16> : i32
+  %acc_seed = arith.constant 23 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 4 : i64
+  %acc_copy_dim1 = arith.constant 4 : i64
+  %acc_copy_element_type = hal.element_type<bf16> : i32
+  %acc_copy_seed = arith.constant 23 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_4x4xbf16_times_4x4xbf16_into_4x4xbf16(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 4 : i64
+  %k = arith.constant 4 : i64
+  %n = arith.constant 4 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxbf16_8_8_8_acc_8() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 8x8x8"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 8 : i64
+  %lhs_dim1 = arith.constant 8 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 24 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 8 : i64
+  %rhs_dim1 = arith.constant 8 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 25 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 8 : i64
+  %acc_dim1 = arith.constant 8 : i64
+  %acc_element_type = hal.element_type<bf16> : i32
+  %acc_seed = arith.constant 26 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 8 : i64
+  %acc_copy_dim1 = arith.constant 8 : i64
+  %acc_copy_element_type = hal.element_type<bf16> : i32
+  %acc_copy_seed = arith.constant 26 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxbf16(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 8 : i64
+  %k = arith.constant 8 : i64
+  %n = arith.constant 8 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_8x8xbf16_times_8x8xbf16_into_8x8xbf16_8_8_8_acc_9() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 8x8x8"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 8 : i64
+  %lhs_dim1 = arith.constant 8 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 27 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 8 : i64
+  %rhs_dim1 = arith.constant 8 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 28 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 8 : i64
+  %acc_dim1 = arith.constant 8 : i64
+  %acc_element_type = hal.element_type<bf16> : i32
+  %acc_seed = arith.constant 29 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 8 : i64
+  %acc_copy_dim1 = arith.constant 8 : i64
+  %acc_copy_element_type = hal.element_type<bf16> : i32
+  %acc_copy_seed = arith.constant 29 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_8x8xbf16_times_8x8xbf16_into_8x8xbf16(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 8 : i64
+  %k = arith.constant 8 : i64
+  %n = arith.constant 8 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxbf16_9_9_9_acc_10() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 9x9x9"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 9 : i64
+  %lhs_dim1 = arith.constant 9 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 30 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 9 : i64
+  %rhs_dim1 = arith.constant 9 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 31 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 9 : i64
+  %acc_dim1 = arith.constant 9 : i64
+  %acc_element_type = hal.element_type<bf16> : i32
+  %acc_seed = arith.constant 32 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 9 : i64
+  %acc_copy_dim1 = arith.constant 9 : i64
+  %acc_copy_element_type = hal.element_type<bf16> : i32
+  %acc_copy_seed = arith.constant 32 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxbf16(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 9 : i64
+  %k = arith.constant 9 : i64
+  %n = arith.constant 9 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_9x9xbf16_times_9x9xbf16_into_9x9xbf16_9_9_9_acc_11() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 9x9x9"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 9 : i64
+  %lhs_dim1 = arith.constant 9 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 33 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 9 : i64
+  %rhs_dim1 = arith.constant 9 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 34 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 9 : i64
+  %acc_dim1 = arith.constant 9 : i64
+  %acc_element_type = hal.element_type<bf16> : i32
+  %acc_seed = arith.constant 35 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 9 : i64
+  %acc_copy_dim1 = arith.constant 9 : i64
+  %acc_copy_element_type = hal.element_type<bf16> : i32
+  %acc_copy_seed = arith.constant 35 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_9x9xbf16_times_9x9xbf16_into_9x9xbf16(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 9 : i64
+  %k = arith.constant 9 : i64
+  %n = arith.constant 9 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxbf16_6_13_3_acc_12() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 6x13x3"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 6 : i64
+  %lhs_dim1 = arith.constant 13 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 36 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 13 : i64
+  %rhs_dim1 = arith.constant 3 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 37 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 6 : i64
+  %acc_dim1 = arith.constant 3 : i64
+  %acc_element_type = hal.element_type<bf16> : i32
+  %acc_seed = arith.constant 38 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 6 : i64
+  %acc_copy_dim1 = arith.constant 3 : i64
+  %acc_copy_element_type = hal.element_type<bf16> : i32
+  %acc_copy_seed = arith.constant 38 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxbf16(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 6 : i64
+  %k = arith.constant 13 : i64
+  %n = arith.constant 3 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_6x13xbf16_times_13x3xbf16_into_6x3xbf16_6_13_3_acc_13() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 6x13x3"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 6 : i64
+  %lhs_dim1 = arith.constant 13 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 39 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 13 : i64
+  %rhs_dim1 = arith.constant 3 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 40 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 6 : i64
+  %acc_dim1 = arith.constant 3 : i64
+  %acc_element_type = hal.element_type<bf16> : i32
+  %acc_seed = arith.constant 41 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 6 : i64
+  %acc_copy_dim1 = arith.constant 3 : i64
+  %acc_copy_element_type = hal.element_type<bf16> : i32
+  %acc_copy_seed = arith.constant 41 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_6x13xbf16_times_13x3xbf16_into_6x3xbf16(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 6 : i64
+  %k = arith.constant 13 : i64
+  %n = arith.constant 3 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxbf16_15_37_7_14() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 15x37x7"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 15 : i64
+  %lhs_dim1 = arith.constant 37 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 42 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 37 : i64
+  %rhs_dim1 = arith.constant 7 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 43 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxbf16(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 15 : i64
+  %k = arith.constant 37 : i64
+  %n = arith.constant 7 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_15x37xbf16_times_37x7xbf16_into_15x7xbf16_15_37_7_15() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 15x37x7"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 15 : i64
+  %lhs_dim1 = arith.constant 37 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 44 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 37 : i64
+  %rhs_dim1 = arith.constant 7 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 45 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_15x37xbf16_times_37x7xbf16_into_15x7xbf16(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 15 : i64
+  %k = arith.constant 37 : i64
+  %n = arith.constant 7 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxbf16_81_19_41_acc_16() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 81x19x41"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 81 : i64
+  %lhs_dim1 = arith.constant 19 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 46 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 19 : i64
+  %rhs_dim1 = arith.constant 41 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 47 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 81 : i64
+  %acc_dim1 = arith.constant 41 : i64
+  %acc_element_type = hal.element_type<bf16> : i32
+  %acc_seed = arith.constant 48 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 81 : i64
+  %acc_copy_dim1 = arith.constant 41 : i64
+  %acc_copy_element_type = hal.element_type<bf16> : i32
+  %acc_copy_seed = arith.constant 48 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxbf16(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 81 : i64
+  %k = arith.constant 19 : i64
+  %n = arith.constant 41 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_81x19xbf16_times_19x41xbf16_into_81x41xbf16_81_19_41_acc_17() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 81x19x41"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 81 : i64
+  %lhs_dim1 = arith.constant 19 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 49 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 19 : i64
+  %rhs_dim1 = arith.constant 41 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 50 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 81 : i64
+  %acc_dim1 = arith.constant 41 : i64
+  %acc_element_type = hal.element_type<bf16> : i32
+  %acc_seed = arith.constant 51 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 81 : i64
+  %acc_copy_dim1 = arith.constant 41 : i64
+  %acc_copy_element_type = hal.element_type<bf16> : i32
+  %acc_copy_seed = arith.constant 51 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_81x19xbf16_times_19x41xbf16_into_81x41xbf16(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 81 : i64
+  %k = arith.constant 19 : i64
+  %n = arith.constant 41 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxbf16_1_10_10_acc_18() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1x10x10"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1 : i64
+  %lhs_dim1 = arith.constant 10 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 52 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 10 : i64
+  %rhs_dim1 = arith.constant 10 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 53 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 1 : i64
+  %acc_dim1 = arith.constant 10 : i64
+  %acc_element_type = hal.element_type<bf16> : i32
+  %acc_seed = arith.constant 54 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 1 : i64
+  %acc_copy_dim1 = arith.constant 10 : i64
+  %acc_copy_element_type = hal.element_type<bf16> : i32
+  %acc_copy_seed = arith.constant 54 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxbf16(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1 : i64
+  %k = arith.constant 10 : i64
+  %n = arith.constant 10 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_1x10xbf16_times_10x10xbf16_into_1x10xbf16_1_10_10_acc_19() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1x10x10"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1 : i64
+  %lhs_dim1 = arith.constant 10 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 55 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 10 : i64
+  %rhs_dim1 = arith.constant 10 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 56 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 1 : i64
+  %acc_dim1 = arith.constant 10 : i64
+  %acc_element_type = hal.element_type<bf16> : i32
+  %acc_seed = arith.constant 57 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 1 : i64
+  %acc_copy_dim1 = arith.constant 10 : i64
+  %acc_copy_element_type = hal.element_type<bf16> : i32
+  %acc_copy_seed = arith.constant 57 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_1x10xbf16_times_10x10xbf16_into_1x10xbf16(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1 : i64
+  %k = arith.constant 10 : i64
+  %n = arith.constant 10 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxbf16_1_10_10_20() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1x10x10"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1 : i64
+  %lhs_dim1 = arith.constant 10 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 58 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 10 : i64
+  %rhs_dim1 = arith.constant 10 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 59 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxbf16(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1 : i64
+  %k = arith.constant 10 : i64
+  %n = arith.constant 10 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_1x10xbf16_times_10x10xbf16_into_1x10xbf16_1_10_10_21() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1x10x10"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1 : i64
+  %lhs_dim1 = arith.constant 10 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 60 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 10 : i64
+  %rhs_dim1 = arith.constant 10 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 61 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_1x10xbf16_times_10x10xbf16_into_1x10xbf16(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1 : i64
+  %k = arith.constant 10 : i64
+  %n = arith.constant 10 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxbf16_10_1_10_acc_22() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 10x1x10"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 10 : i64
+  %lhs_dim1 = arith.constant 1 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 62 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1 : i64
+  %rhs_dim1 = arith.constant 10 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 63 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 10 : i64
+  %acc_dim1 = arith.constant 10 : i64
+  %acc_element_type = hal.element_type<bf16> : i32
+  %acc_seed = arith.constant 64 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 10 : i64
+  %acc_copy_dim1 = arith.constant 10 : i64
+  %acc_copy_element_type = hal.element_type<bf16> : i32
+  %acc_copy_seed = arith.constant 64 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxbf16(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 10 : i64
+  %k = arith.constant 1 : i64
+  %n = arith.constant 10 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_10x1xbf16_times_1x10xbf16_into_10x10xbf16_10_1_10_acc_23() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 10x1x10"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 10 : i64
+  %lhs_dim1 = arith.constant 1 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 65 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1 : i64
+  %rhs_dim1 = arith.constant 10 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 66 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 10 : i64
+  %acc_dim1 = arith.constant 10 : i64
+  %acc_element_type = hal.element_type<bf16> : i32
+  %acc_seed = arith.constant 67 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 10 : i64
+  %acc_copy_dim1 = arith.constant 10 : i64
+  %acc_copy_element_type = hal.element_type<bf16> : i32
+  %acc_copy_seed = arith.constant 67 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_10x1xbf16_times_1x10xbf16_into_10x10xbf16(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 10 : i64
+  %k = arith.constant 1 : i64
+  %n = arith.constant 10 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxbf16_10_10_1_acc_24() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 10x10x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 10 : i64
+  %lhs_dim1 = arith.constant 10 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 68 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 10 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 69 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 10 : i64
+  %acc_dim1 = arith.constant 1 : i64
+  %acc_element_type = hal.element_type<bf16> : i32
+  %acc_seed = arith.constant 70 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 10 : i64
+  %acc_copy_dim1 = arith.constant 1 : i64
+  %acc_copy_element_type = hal.element_type<bf16> : i32
+  %acc_copy_seed = arith.constant 70 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxbf16(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 10 : i64
+  %k = arith.constant 10 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_10x10xbf16_times_10x1xbf16_into_10x1xbf16_10_10_1_acc_25() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 10x10x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 10 : i64
+  %lhs_dim1 = arith.constant 10 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 71 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 10 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 72 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 10 : i64
+  %acc_dim1 = arith.constant 1 : i64
+  %acc_element_type = hal.element_type<bf16> : i32
+  %acc_seed = arith.constant 73 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 10 : i64
+  %acc_copy_dim1 = arith.constant 1 : i64
+  %acc_copy_element_type = hal.element_type<bf16> : i32
+  %acc_copy_seed = arith.constant 73 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_10x10xbf16_times_10x1xbf16_into_10x1xbf16(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 10 : i64
+  %k = arith.constant 10 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxbf16_10_10_1_26() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 10x10x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 10 : i64
+  %lhs_dim1 = arith.constant 10 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 74 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 10 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 75 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxbf16(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 10 : i64
+  %k = arith.constant 10 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_10x10xbf16_times_10x1xbf16_into_10x1xbf16_10_10_1_27() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 10x10x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 10 : i64
+  %lhs_dim1 = arith.constant 10 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 76 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 10 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 77 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_10x10xbf16_times_10x1xbf16_into_10x1xbf16(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 10 : i64
+  %k = arith.constant 10 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+
+}

--- a/matmul/tests/generated/matmul_bf16_bf16_small_matmul.mlir
+++ b/matmul/tests/generated/matmul_bf16_bf16_small_matmul.mlir
@@ -1,0 +1,99 @@
+func.func @matmul_accumulate_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxbf16(%lhs: tensor<?x?xbf16>, %rhs: tensor<?x?xbf16>, %acc: tensor<?x?xbf16>) -> tensor<?x?xbf16> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<?x?xbf16>, tensor<?x?xbf16>) outs(%acc: tensor<?x?xbf16>) -> tensor<?x?xbf16>
+  return %result: tensor<?x?xbf16>
+}
+
+func.func @matmul_accumulate_1x1xbf16_times_1x1xbf16_into_1x1xbf16(%lhs: tensor<1x1xbf16>, %rhs: tensor<1x1xbf16>, %acc: tensor<1x1xbf16>) -> tensor<1x1xbf16> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<1x1xbf16>, tensor<1x1xbf16>) outs(%acc: tensor<1x1xbf16>) -> tensor<1x1xbf16>
+  return %result: tensor<1x1xbf16>
+}
+
+func.func @matmul_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxbf16(%lhs: tensor<?x?xbf16>, %rhs: tensor<?x?xbf16>) -> tensor<?x?xbf16> {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %acc_dim0 = tensor.dim %lhs, %c0 : tensor<?x?xbf16>
+  %acc_dim1 = tensor.dim %rhs, %c1 : tensor<?x?xbf16>
+  %init_acc = tensor.empty(%acc_dim0, %acc_dim1) : tensor<?x?xbf16>
+  %c0_acc_type = arith.constant 0.0: bf16
+  %acc = linalg.fill ins(%c0_acc_type : bf16) outs(%init_acc : tensor<?x?xbf16>) -> tensor<?x?xbf16>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<?x?xbf16>, tensor<?x?xbf16>) outs(%acc: tensor<?x?xbf16>) -> tensor<?x?xbf16>
+  return %result: tensor<?x?xbf16>
+}
+
+func.func @matmul_1x1xbf16_times_1x1xbf16_into_1x1xbf16(%lhs: tensor<1x1xbf16>, %rhs: tensor<1x1xbf16>) -> tensor<1x1xbf16> {
+  %init_acc = tensor.empty() : tensor<1x1xbf16>
+  %c0_acc_type = arith.constant 0.0: bf16
+  %acc = linalg.fill ins(%c0_acc_type : bf16) outs(%init_acc : tensor<1x1xbf16>) -> tensor<1x1xbf16>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<1x1xbf16>, tensor<1x1xbf16>) outs(%acc: tensor<1x1xbf16>) -> tensor<1x1xbf16>
+  return %result: tensor<1x1xbf16>
+}
+
+func.func @matmul_accumulate_2x2xbf16_times_2x2xbf16_into_2x2xbf16(%lhs: tensor<2x2xbf16>, %rhs: tensor<2x2xbf16>, %acc: tensor<2x2xbf16>) -> tensor<2x2xbf16> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<2x2xbf16>, tensor<2x2xbf16>) outs(%acc: tensor<2x2xbf16>) -> tensor<2x2xbf16>
+  return %result: tensor<2x2xbf16>
+}
+
+func.func @matmul_accumulate_4x4xbf16_times_4x4xbf16_into_4x4xbf16(%lhs: tensor<4x4xbf16>, %rhs: tensor<4x4xbf16>, %acc: tensor<4x4xbf16>) -> tensor<4x4xbf16> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<4x4xbf16>, tensor<4x4xbf16>) outs(%acc: tensor<4x4xbf16>) -> tensor<4x4xbf16>
+  return %result: tensor<4x4xbf16>
+}
+
+func.func @matmul_accumulate_8x8xbf16_times_8x8xbf16_into_8x8xbf16(%lhs: tensor<8x8xbf16>, %rhs: tensor<8x8xbf16>, %acc: tensor<8x8xbf16>) -> tensor<8x8xbf16> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<8x8xbf16>, tensor<8x8xbf16>) outs(%acc: tensor<8x8xbf16>) -> tensor<8x8xbf16>
+  return %result: tensor<8x8xbf16>
+}
+
+func.func @matmul_accumulate_9x9xbf16_times_9x9xbf16_into_9x9xbf16(%lhs: tensor<9x9xbf16>, %rhs: tensor<9x9xbf16>, %acc: tensor<9x9xbf16>) -> tensor<9x9xbf16> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<9x9xbf16>, tensor<9x9xbf16>) outs(%acc: tensor<9x9xbf16>) -> tensor<9x9xbf16>
+  return %result: tensor<9x9xbf16>
+}
+
+func.func @matmul_accumulate_6x13xbf16_times_13x3xbf16_into_6x3xbf16(%lhs: tensor<6x13xbf16>, %rhs: tensor<13x3xbf16>, %acc: tensor<6x3xbf16>) -> tensor<6x3xbf16> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<6x13xbf16>, tensor<13x3xbf16>) outs(%acc: tensor<6x3xbf16>) -> tensor<6x3xbf16>
+  return %result: tensor<6x3xbf16>
+}
+
+func.func @matmul_15x37xbf16_times_37x7xbf16_into_15x7xbf16(%lhs: tensor<15x37xbf16>, %rhs: tensor<37x7xbf16>) -> tensor<15x7xbf16> {
+  %init_acc = tensor.empty() : tensor<15x7xbf16>
+  %c0_acc_type = arith.constant 0.0: bf16
+  %acc = linalg.fill ins(%c0_acc_type : bf16) outs(%init_acc : tensor<15x7xbf16>) -> tensor<15x7xbf16>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<15x37xbf16>, tensor<37x7xbf16>) outs(%acc: tensor<15x7xbf16>) -> tensor<15x7xbf16>
+  return %result: tensor<15x7xbf16>
+}
+
+func.func @matmul_accumulate_81x19xbf16_times_19x41xbf16_into_81x41xbf16(%lhs: tensor<81x19xbf16>, %rhs: tensor<19x41xbf16>, %acc: tensor<81x41xbf16>) -> tensor<81x41xbf16> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<81x19xbf16>, tensor<19x41xbf16>) outs(%acc: tensor<81x41xbf16>) -> tensor<81x41xbf16>
+  return %result: tensor<81x41xbf16>
+}
+
+func.func @matmul_accumulate_1x10xbf16_times_10x10xbf16_into_1x10xbf16(%lhs: tensor<1x10xbf16>, %rhs: tensor<10x10xbf16>, %acc: tensor<1x10xbf16>) -> tensor<1x10xbf16> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<1x10xbf16>, tensor<10x10xbf16>) outs(%acc: tensor<1x10xbf16>) -> tensor<1x10xbf16>
+  return %result: tensor<1x10xbf16>
+}
+
+func.func @matmul_1x10xbf16_times_10x10xbf16_into_1x10xbf16(%lhs: tensor<1x10xbf16>, %rhs: tensor<10x10xbf16>) -> tensor<1x10xbf16> {
+  %init_acc = tensor.empty() : tensor<1x10xbf16>
+  %c0_acc_type = arith.constant 0.0: bf16
+  %acc = linalg.fill ins(%c0_acc_type : bf16) outs(%init_acc : tensor<1x10xbf16>) -> tensor<1x10xbf16>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<1x10xbf16>, tensor<10x10xbf16>) outs(%acc: tensor<1x10xbf16>) -> tensor<1x10xbf16>
+  return %result: tensor<1x10xbf16>
+}
+
+func.func @matmul_accumulate_10x1xbf16_times_1x10xbf16_into_10x10xbf16(%lhs: tensor<10x1xbf16>, %rhs: tensor<1x10xbf16>, %acc: tensor<10x10xbf16>) -> tensor<10x10xbf16> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<10x1xbf16>, tensor<1x10xbf16>) outs(%acc: tensor<10x10xbf16>) -> tensor<10x10xbf16>
+  return %result: tensor<10x10xbf16>
+}
+
+func.func @matmul_accumulate_10x10xbf16_times_10x1xbf16_into_10x1xbf16(%lhs: tensor<10x10xbf16>, %rhs: tensor<10x1xbf16>, %acc: tensor<10x1xbf16>) -> tensor<10x1xbf16> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<10x10xbf16>, tensor<10x1xbf16>) outs(%acc: tensor<10x1xbf16>) -> tensor<10x1xbf16>
+  return %result: tensor<10x1xbf16>
+}
+
+func.func @matmul_10x10xbf16_times_10x1xbf16_into_10x1xbf16(%lhs: tensor<10x10xbf16>, %rhs: tensor<10x1xbf16>) -> tensor<10x1xbf16> {
+  %init_acc = tensor.empty() : tensor<10x1xbf16>
+  %c0_acc_type = arith.constant 0.0: bf16
+  %acc = linalg.fill ins(%c0_acc_type : bf16) outs(%init_acc : tensor<10x1xbf16>) -> tensor<10x1xbf16>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<10x10xbf16>, tensor<10x1xbf16>) outs(%acc: tensor<10x1xbf16>) -> tensor<10x1xbf16>
+  return %result: tensor<10x1xbf16>
+}
+

--- a/matmul/tests/generated/matmul_bf16_f32_gpu_large_aligned_calls.mlir
+++ b/matmul/tests/generated/matmul_bf16_f32_gpu_large_aligned_calls.mlir
@@ -1,0 +1,71 @@
+builtin.module @calls attributes {
+  
+} {
+
+func.func private @matmul_test.generate_random_matrix(%device: !hal.device, %dim0: i64, %dim1: i64, %element_type: i32, %seed: i32) -> !hal.buffer_view
+func.func private @matmul_test.check_matmul_results(%device: !hal.device, %m: i64, %k: i64, %n: i64, %transpose_rhs: i32, %lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view, %actual_result: !hal.buffer_view)
+
+func.func private @module.matmul_accumulate_512x128xbf16_times_128x512xbf16_into_512x512xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_512x128xbf16_times_128x512xbf16_into_512x512xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+
+func.func @matmul_accumulate_512x128xbf16_times_128x512xbf16_into_512x512xf32_512_128_512_acc_0() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 512x128x512"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 512 : i64
+  %lhs_dim1 = arith.constant 128 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 2 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 128 : i64
+  %rhs_dim1 = arith.constant 512 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 3 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 512 : i64
+  %acc_dim1 = arith.constant 512 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 4 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 512 : i64
+  %acc_copy_dim1 = arith.constant 512 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 4 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_512x128xbf16_times_128x512xbf16_into_512x512xf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 512 : i64
+  %k = arith.constant 128 : i64
+  %n = arith.constant 512 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_512x128xbf16_times_128x512xbf16_into_512x512xf32_512_128_512_1() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 512x128x512"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 512 : i64
+  %lhs_dim1 = arith.constant 128 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 5 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 128 : i64
+  %rhs_dim1 = arith.constant 512 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 6 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_512x128xbf16_times_128x512xbf16_into_512x512xf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 512 : i64
+  %k = arith.constant 128 : i64
+  %n = arith.constant 512 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+
+}

--- a/matmul/tests/generated/matmul_bf16_f32_gpu_large_aligned_matmul.mlir
+++ b/matmul/tests/generated/matmul_bf16_f32_gpu_large_aligned_matmul.mlir
@@ -1,0 +1,13 @@
+func.func @matmul_accumulate_512x128xbf16_times_128x512xbf16_into_512x512xf32(%lhs: tensor<512x128xbf16>, %rhs: tensor<128x512xbf16>, %acc: tensor<512x512xf32>) -> tensor<512x512xf32> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<512x128xbf16>, tensor<128x512xbf16>) outs(%acc: tensor<512x512xf32>) -> tensor<512x512xf32>
+  return %result: tensor<512x512xf32>
+}
+
+func.func @matmul_512x128xbf16_times_128x512xbf16_into_512x512xf32(%lhs: tensor<512x128xbf16>, %rhs: tensor<128x512xbf16>) -> tensor<512x512xf32> {
+  %init_acc = tensor.empty() : tensor<512x512xf32>
+  %c0_acc_type = arith.constant 0.0: f32
+  %acc = linalg.fill ins(%c0_acc_type : f32) outs(%init_acc : tensor<512x512xf32>) -> tensor<512x512xf32>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<512x128xbf16>, tensor<128x512xbf16>) outs(%acc: tensor<512x512xf32>) -> tensor<512x512xf32>
+  return %result: tensor<512x512xf32>
+}
+

--- a/matmul/tests/generated/matmul_bf16_f32_gpu_large_calls.mlir
+++ b/matmul/tests/generated/matmul_bf16_f32_gpu_large_calls.mlir
@@ -1,0 +1,270 @@
+builtin.module @calls attributes {
+  
+} {
+
+func.func private @matmul_test.generate_random_matrix(%device: !hal.device, %dim0: i64, %dim1: i64, %element_type: i32, %seed: i32) -> !hal.buffer_view
+func.func private @matmul_test.check_matmul_results(%device: !hal.device, %m: i64, %k: i64, %n: i64, %transpose_rhs: i32, %lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view, %actual_result: !hal.buffer_view)
+
+func.func private @module.matmul_457x330xbf16_times_330x512xbf16_into_457x512xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_457x330xbf16_times_330x514xbf16_into_457x514xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_438x330xbf16_times_330x514xbf16_into_438x514xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_540x332xbf16_times_332x516xbf16_into_540x516xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_1000x4xbf16_times_4x512xbf16_into_1000x512xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_4x1000xbf16_times_1000x512xbf16_into_4x512xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_512x1000xbf16_times_1000x4xbf16_into_512x4xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_512x128xbf16_times_128x500xbf16_into_512x500xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_457x160xbf16_times_160x512xbf16_into_457x512xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_512x330xbf16_times_330x512xbf16_into_512x512xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+
+func.func @matmul_457x330xbf16_times_330x512xbf16_into_457x512xf32_457_330_512_0() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 457x330x512"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 457 : i64
+  %lhs_dim1 = arith.constant 330 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 2 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 330 : i64
+  %rhs_dim1 = arith.constant 512 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 3 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_457x330xbf16_times_330x512xbf16_into_457x512xf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 457 : i64
+  %k = arith.constant 330 : i64
+  %n = arith.constant 512 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_457x330xbf16_times_330x514xbf16_into_457x514xf32_457_330_514_1() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 457x330x514"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 457 : i64
+  %lhs_dim1 = arith.constant 330 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 4 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 330 : i64
+  %rhs_dim1 = arith.constant 514 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 5 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_457x330xbf16_times_330x514xbf16_into_457x514xf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 457 : i64
+  %k = arith.constant 330 : i64
+  %n = arith.constant 514 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_438x330xbf16_times_330x514xbf16_into_438x514xf32_438_330_514_2() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 438x330x514"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 438 : i64
+  %lhs_dim1 = arith.constant 330 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 6 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 330 : i64
+  %rhs_dim1 = arith.constant 514 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 7 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_438x330xbf16_times_330x514xbf16_into_438x514xf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 438 : i64
+  %k = arith.constant 330 : i64
+  %n = arith.constant 514 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_540x332xbf16_times_332x516xbf16_into_540x516xf32_540_332_516_3() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 540x332x516"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 540 : i64
+  %lhs_dim1 = arith.constant 332 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 8 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 332 : i64
+  %rhs_dim1 = arith.constant 516 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 9 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_540x332xbf16_times_332x516xbf16_into_540x516xf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 540 : i64
+  %k = arith.constant 332 : i64
+  %n = arith.constant 516 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_1000x4xbf16_times_4x512xbf16_into_1000x512xf32_1000_4_512_4() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1000x4x512"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1000 : i64
+  %lhs_dim1 = arith.constant 4 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 10 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 4 : i64
+  %rhs_dim1 = arith.constant 512 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 11 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_1000x4xbf16_times_4x512xbf16_into_1000x512xf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1000 : i64
+  %k = arith.constant 4 : i64
+  %n = arith.constant 512 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_4x1000xbf16_times_1000x512xbf16_into_4x512xf32_4_1000_512_5() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 4x1000x512"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 4 : i64
+  %lhs_dim1 = arith.constant 1000 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 12 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1000 : i64
+  %rhs_dim1 = arith.constant 512 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 13 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_4x1000xbf16_times_1000x512xbf16_into_4x512xf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 4 : i64
+  %k = arith.constant 1000 : i64
+  %n = arith.constant 512 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_512x1000xbf16_times_1000x4xbf16_into_512x4xf32_512_1000_4_6() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 512x1000x4"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 512 : i64
+  %lhs_dim1 = arith.constant 1000 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 14 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1000 : i64
+  %rhs_dim1 = arith.constant 4 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 15 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_512x1000xbf16_times_1000x4xbf16_into_512x4xf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 512 : i64
+  %k = arith.constant 1000 : i64
+  %n = arith.constant 4 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_512x128xbf16_times_128x500xbf16_into_512x500xf32_512_128_500_7() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 512x128x500"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 512 : i64
+  %lhs_dim1 = arith.constant 128 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 16 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 128 : i64
+  %rhs_dim1 = arith.constant 500 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 17 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_512x128xbf16_times_128x500xbf16_into_512x500xf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 512 : i64
+  %k = arith.constant 128 : i64
+  %n = arith.constant 500 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_457x160xbf16_times_160x512xbf16_into_457x512xf32_457_160_512_8() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 457x160x512"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 457 : i64
+  %lhs_dim1 = arith.constant 160 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 18 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 160 : i64
+  %rhs_dim1 = arith.constant 512 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 19 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_457x160xbf16_times_160x512xbf16_into_457x512xf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 457 : i64
+  %k = arith.constant 160 : i64
+  %n = arith.constant 512 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_512x330xbf16_times_330x512xbf16_into_512x512xf32_512_330_512_9() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 512x330x512"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 512 : i64
+  %lhs_dim1 = arith.constant 330 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 20 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 330 : i64
+  %rhs_dim1 = arith.constant 512 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 21 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_512x330xbf16_times_330x512xbf16_into_512x512xf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 512 : i64
+  %k = arith.constant 330 : i64
+  %n = arith.constant 512 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+
+}

--- a/matmul/tests/generated/matmul_bf16_f32_gpu_large_matmul.mlir
+++ b/matmul/tests/generated/matmul_bf16_f32_gpu_large_matmul.mlir
@@ -1,0 +1,80 @@
+func.func @matmul_457x330xbf16_times_330x512xbf16_into_457x512xf32(%lhs: tensor<457x330xbf16>, %rhs: tensor<330x512xbf16>) -> tensor<457x512xf32> {
+  %init_acc = tensor.empty() : tensor<457x512xf32>
+  %c0_acc_type = arith.constant 0.0: f32
+  %acc = linalg.fill ins(%c0_acc_type : f32) outs(%init_acc : tensor<457x512xf32>) -> tensor<457x512xf32>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<457x330xbf16>, tensor<330x512xbf16>) outs(%acc: tensor<457x512xf32>) -> tensor<457x512xf32>
+  return %result: tensor<457x512xf32>
+}
+
+func.func @matmul_457x330xbf16_times_330x514xbf16_into_457x514xf32(%lhs: tensor<457x330xbf16>, %rhs: tensor<330x514xbf16>) -> tensor<457x514xf32> {
+  %init_acc = tensor.empty() : tensor<457x514xf32>
+  %c0_acc_type = arith.constant 0.0: f32
+  %acc = linalg.fill ins(%c0_acc_type : f32) outs(%init_acc : tensor<457x514xf32>) -> tensor<457x514xf32>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<457x330xbf16>, tensor<330x514xbf16>) outs(%acc: tensor<457x514xf32>) -> tensor<457x514xf32>
+  return %result: tensor<457x514xf32>
+}
+
+func.func @matmul_438x330xbf16_times_330x514xbf16_into_438x514xf32(%lhs: tensor<438x330xbf16>, %rhs: tensor<330x514xbf16>) -> tensor<438x514xf32> {
+  %init_acc = tensor.empty() : tensor<438x514xf32>
+  %c0_acc_type = arith.constant 0.0: f32
+  %acc = linalg.fill ins(%c0_acc_type : f32) outs(%init_acc : tensor<438x514xf32>) -> tensor<438x514xf32>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<438x330xbf16>, tensor<330x514xbf16>) outs(%acc: tensor<438x514xf32>) -> tensor<438x514xf32>
+  return %result: tensor<438x514xf32>
+}
+
+func.func @matmul_540x332xbf16_times_332x516xbf16_into_540x516xf32(%lhs: tensor<540x332xbf16>, %rhs: tensor<332x516xbf16>) -> tensor<540x516xf32> {
+  %init_acc = tensor.empty() : tensor<540x516xf32>
+  %c0_acc_type = arith.constant 0.0: f32
+  %acc = linalg.fill ins(%c0_acc_type : f32) outs(%init_acc : tensor<540x516xf32>) -> tensor<540x516xf32>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<540x332xbf16>, tensor<332x516xbf16>) outs(%acc: tensor<540x516xf32>) -> tensor<540x516xf32>
+  return %result: tensor<540x516xf32>
+}
+
+func.func @matmul_1000x4xbf16_times_4x512xbf16_into_1000x512xf32(%lhs: tensor<1000x4xbf16>, %rhs: tensor<4x512xbf16>) -> tensor<1000x512xf32> {
+  %init_acc = tensor.empty() : tensor<1000x512xf32>
+  %c0_acc_type = arith.constant 0.0: f32
+  %acc = linalg.fill ins(%c0_acc_type : f32) outs(%init_acc : tensor<1000x512xf32>) -> tensor<1000x512xf32>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<1000x4xbf16>, tensor<4x512xbf16>) outs(%acc: tensor<1000x512xf32>) -> tensor<1000x512xf32>
+  return %result: tensor<1000x512xf32>
+}
+
+func.func @matmul_4x1000xbf16_times_1000x512xbf16_into_4x512xf32(%lhs: tensor<4x1000xbf16>, %rhs: tensor<1000x512xbf16>) -> tensor<4x512xf32> {
+  %init_acc = tensor.empty() : tensor<4x512xf32>
+  %c0_acc_type = arith.constant 0.0: f32
+  %acc = linalg.fill ins(%c0_acc_type : f32) outs(%init_acc : tensor<4x512xf32>) -> tensor<4x512xf32>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<4x1000xbf16>, tensor<1000x512xbf16>) outs(%acc: tensor<4x512xf32>) -> tensor<4x512xf32>
+  return %result: tensor<4x512xf32>
+}
+
+func.func @matmul_512x1000xbf16_times_1000x4xbf16_into_512x4xf32(%lhs: tensor<512x1000xbf16>, %rhs: tensor<1000x4xbf16>) -> tensor<512x4xf32> {
+  %init_acc = tensor.empty() : tensor<512x4xf32>
+  %c0_acc_type = arith.constant 0.0: f32
+  %acc = linalg.fill ins(%c0_acc_type : f32) outs(%init_acc : tensor<512x4xf32>) -> tensor<512x4xf32>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<512x1000xbf16>, tensor<1000x4xbf16>) outs(%acc: tensor<512x4xf32>) -> tensor<512x4xf32>
+  return %result: tensor<512x4xf32>
+}
+
+func.func @matmul_512x128xbf16_times_128x500xbf16_into_512x500xf32(%lhs: tensor<512x128xbf16>, %rhs: tensor<128x500xbf16>) -> tensor<512x500xf32> {
+  %init_acc = tensor.empty() : tensor<512x500xf32>
+  %c0_acc_type = arith.constant 0.0: f32
+  %acc = linalg.fill ins(%c0_acc_type : f32) outs(%init_acc : tensor<512x500xf32>) -> tensor<512x500xf32>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<512x128xbf16>, tensor<128x500xbf16>) outs(%acc: tensor<512x500xf32>) -> tensor<512x500xf32>
+  return %result: tensor<512x500xf32>
+}
+
+func.func @matmul_457x160xbf16_times_160x512xbf16_into_457x512xf32(%lhs: tensor<457x160xbf16>, %rhs: tensor<160x512xbf16>) -> tensor<457x512xf32> {
+  %init_acc = tensor.empty() : tensor<457x512xf32>
+  %c0_acc_type = arith.constant 0.0: f32
+  %acc = linalg.fill ins(%c0_acc_type : f32) outs(%init_acc : tensor<457x512xf32>) -> tensor<457x512xf32>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<457x160xbf16>, tensor<160x512xbf16>) outs(%acc: tensor<457x512xf32>) -> tensor<457x512xf32>
+  return %result: tensor<457x512xf32>
+}
+
+func.func @matmul_512x330xbf16_times_330x512xbf16_into_512x512xf32(%lhs: tensor<512x330xbf16>, %rhs: tensor<330x512xbf16>) -> tensor<512x512xf32> {
+  %init_acc = tensor.empty() : tensor<512x512xf32>
+  %c0_acc_type = arith.constant 0.0: f32
+  %acc = linalg.fill ins(%c0_acc_type : f32) outs(%init_acc : tensor<512x512xf32>) -> tensor<512x512xf32>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<512x330xbf16>, tensor<330x512xbf16>) outs(%acc: tensor<512x512xf32>) -> tensor<512x512xf32>
+  return %result: tensor<512x512xf32>
+}
+

--- a/matmul/tests/generated/matmul_bf16_f32_large_calls.mlir
+++ b/matmul/tests/generated/matmul_bf16_f32_large_calls.mlir
@@ -1,0 +1,321 @@
+builtin.module @calls attributes {
+  
+} {
+
+func.func private @matmul_test.generate_random_matrix(%device: !hal.device, %dim0: i64, %dim1: i64, %element_type: i32, %seed: i32) -> !hal.buffer_view
+func.func private @matmul_test.check_matmul_results(%device: !hal.device, %m: i64, %k: i64, %n: i64, %transpose_rhs: i32, %lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view, %actual_result: !hal.buffer_view)
+
+func.func private @module.matmul_accumulate_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_123x456xbf16_times_456x789xbf16_into_123x789xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_654x321xbf16_times_321x234xbf16_into_654x234xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_1x1000xbf16_times_1000x1000xbf16_into_1x1000xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_1000x1000xbf16_times_1000x1xbf16_into_1000x1xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_1000x1000xbf16_times_1000x1xbf16_into_1000x1xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+
+func.func @matmul_accumulate_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxf32_123_456_789_acc_0() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 123x456x789"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 123 : i64
+  %lhs_dim1 = arith.constant 456 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 2 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 456 : i64
+  %rhs_dim1 = arith.constant 789 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 3 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 123 : i64
+  %acc_dim1 = arith.constant 789 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 4 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 123 : i64
+  %acc_copy_dim1 = arith.constant 789 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 4 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 123 : i64
+  %k = arith.constant 456 : i64
+  %n = arith.constant 789 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_123x456xbf16_times_456x789xbf16_into_123x789xf32_123_456_789_acc_1() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 123x456x789"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 123 : i64
+  %lhs_dim1 = arith.constant 456 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 5 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 456 : i64
+  %rhs_dim1 = arith.constant 789 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 6 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 123 : i64
+  %acc_dim1 = arith.constant 789 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 7 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 123 : i64
+  %acc_copy_dim1 = arith.constant 789 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 7 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_123x456xbf16_times_456x789xbf16_into_123x789xf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 123 : i64
+  %k = arith.constant 456 : i64
+  %n = arith.constant 789 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxf32_654_321_234_2() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 654x321x234"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 654 : i64
+  %lhs_dim1 = arith.constant 321 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 8 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 321 : i64
+  %rhs_dim1 = arith.constant 234 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 9 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 654 : i64
+  %k = arith.constant 321 : i64
+  %n = arith.constant 234 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_654x321xbf16_times_321x234xbf16_into_654x234xf32_654_321_234_3() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 654x321x234"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 654 : i64
+  %lhs_dim1 = arith.constant 321 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 10 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 321 : i64
+  %rhs_dim1 = arith.constant 234 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 11 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_654x321xbf16_times_321x234xbf16_into_654x234xf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 654 : i64
+  %k = arith.constant 321 : i64
+  %n = arith.constant 234 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxf32_1_1000_1000_acc_4() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1x1000x1000"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1 : i64
+  %lhs_dim1 = arith.constant 1000 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 12 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1000 : i64
+  %rhs_dim1 = arith.constant 1000 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 13 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 1 : i64
+  %acc_dim1 = arith.constant 1000 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 14 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 1 : i64
+  %acc_copy_dim1 = arith.constant 1000 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 14 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1 : i64
+  %k = arith.constant 1000 : i64
+  %n = arith.constant 1000 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_1x1000xbf16_times_1000x1000xbf16_into_1x1000xf32_1_1000_1000_acc_5() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1x1000x1000"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1 : i64
+  %lhs_dim1 = arith.constant 1000 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 15 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1000 : i64
+  %rhs_dim1 = arith.constant 1000 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 16 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 1 : i64
+  %acc_dim1 = arith.constant 1000 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 17 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 1 : i64
+  %acc_copy_dim1 = arith.constant 1000 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 17 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_1x1000xbf16_times_1000x1000xbf16_into_1x1000xf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1 : i64
+  %k = arith.constant 1000 : i64
+  %n = arith.constant 1000 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxf32_1000_1000_1_acc_6() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1000x1000x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1000 : i64
+  %lhs_dim1 = arith.constant 1000 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 18 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1000 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 19 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 1000 : i64
+  %acc_dim1 = arith.constant 1 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 20 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 1000 : i64
+  %acc_copy_dim1 = arith.constant 1 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 20 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1000 : i64
+  %k = arith.constant 1000 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_1000x1000xbf16_times_1000x1xbf16_into_1000x1xf32_1000_1000_1_acc_7() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1000x1000x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1000 : i64
+  %lhs_dim1 = arith.constant 1000 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 21 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1000 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 22 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 1000 : i64
+  %acc_dim1 = arith.constant 1 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 23 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 1000 : i64
+  %acc_copy_dim1 = arith.constant 1 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 23 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_1000x1000xbf16_times_1000x1xbf16_into_1000x1xf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1000 : i64
+  %k = arith.constant 1000 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxf32_1000_1000_1_8() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1000x1000x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1000 : i64
+  %lhs_dim1 = arith.constant 1000 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 24 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1000 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 25 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1000 : i64
+  %k = arith.constant 1000 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_1000x1000xbf16_times_1000x1xbf16_into_1000x1xf32_1000_1000_1_9() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1000x1000x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1000 : i64
+  %lhs_dim1 = arith.constant 1000 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 26 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1000 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 27 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_1000x1000xbf16_times_1000x1xbf16_into_1000x1xf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1000 : i64
+  %k = arith.constant 1000 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+
+}

--- a/matmul/tests/generated/matmul_bf16_f32_large_matmul.mlir
+++ b/matmul/tests/generated/matmul_bf16_f32_large_matmul.mlir
@@ -1,0 +1,48 @@
+func.func @matmul_accumulate_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxf32(%lhs: tensor<?x?xbf16>, %rhs: tensor<?x?xbf16>, %acc: tensor<?x?xf32>) -> tensor<?x?xf32> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<?x?xbf16>, tensor<?x?xbf16>) outs(%acc: tensor<?x?xf32>) -> tensor<?x?xf32>
+  return %result: tensor<?x?xf32>
+}
+
+func.func @matmul_accumulate_123x456xbf16_times_456x789xbf16_into_123x789xf32(%lhs: tensor<123x456xbf16>, %rhs: tensor<456x789xbf16>, %acc: tensor<123x789xf32>) -> tensor<123x789xf32> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<123x456xbf16>, tensor<456x789xbf16>) outs(%acc: tensor<123x789xf32>) -> tensor<123x789xf32>
+  return %result: tensor<123x789xf32>
+}
+
+func.func @matmul_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxf32(%lhs: tensor<?x?xbf16>, %rhs: tensor<?x?xbf16>) -> tensor<?x?xf32> {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %acc_dim0 = tensor.dim %lhs, %c0 : tensor<?x?xbf16>
+  %acc_dim1 = tensor.dim %rhs, %c1 : tensor<?x?xbf16>
+  %init_acc = tensor.empty(%acc_dim0, %acc_dim1) : tensor<?x?xf32>
+  %c0_acc_type = arith.constant 0.0: f32
+  %acc = linalg.fill ins(%c0_acc_type : f32) outs(%init_acc : tensor<?x?xf32>) -> tensor<?x?xf32>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<?x?xbf16>, tensor<?x?xbf16>) outs(%acc: tensor<?x?xf32>) -> tensor<?x?xf32>
+  return %result: tensor<?x?xf32>
+}
+
+func.func @matmul_654x321xbf16_times_321x234xbf16_into_654x234xf32(%lhs: tensor<654x321xbf16>, %rhs: tensor<321x234xbf16>) -> tensor<654x234xf32> {
+  %init_acc = tensor.empty() : tensor<654x234xf32>
+  %c0_acc_type = arith.constant 0.0: f32
+  %acc = linalg.fill ins(%c0_acc_type : f32) outs(%init_acc : tensor<654x234xf32>) -> tensor<654x234xf32>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<654x321xbf16>, tensor<321x234xbf16>) outs(%acc: tensor<654x234xf32>) -> tensor<654x234xf32>
+  return %result: tensor<654x234xf32>
+}
+
+func.func @matmul_accumulate_1x1000xbf16_times_1000x1000xbf16_into_1x1000xf32(%lhs: tensor<1x1000xbf16>, %rhs: tensor<1000x1000xbf16>, %acc: tensor<1x1000xf32>) -> tensor<1x1000xf32> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<1x1000xbf16>, tensor<1000x1000xbf16>) outs(%acc: tensor<1x1000xf32>) -> tensor<1x1000xf32>
+  return %result: tensor<1x1000xf32>
+}
+
+func.func @matmul_accumulate_1000x1000xbf16_times_1000x1xbf16_into_1000x1xf32(%lhs: tensor<1000x1000xbf16>, %rhs: tensor<1000x1xbf16>, %acc: tensor<1000x1xf32>) -> tensor<1000x1xf32> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<1000x1000xbf16>, tensor<1000x1xbf16>) outs(%acc: tensor<1000x1xf32>) -> tensor<1000x1xf32>
+  return %result: tensor<1000x1xf32>
+}
+
+func.func @matmul_1000x1000xbf16_times_1000x1xbf16_into_1000x1xf32(%lhs: tensor<1000x1000xbf16>, %rhs: tensor<1000x1xbf16>) -> tensor<1000x1xf32> {
+  %init_acc = tensor.empty() : tensor<1000x1xf32>
+  %c0_acc_type = arith.constant 0.0: f32
+  %acc = linalg.fill ins(%c0_acc_type : f32) outs(%init_acc : tensor<1000x1xf32>) -> tensor<1000x1xf32>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<1000x1000xbf16>, tensor<1000x1xbf16>) outs(%acc: tensor<1000x1xf32>) -> tensor<1000x1xf32>
+  return %result: tensor<1000x1xf32>
+}
+

--- a/matmul/tests/generated/matmul_bf16_f32_small_calls.mlir
+++ b/matmul/tests/generated/matmul_bf16_f32_small_calls.mlir
@@ -1,0 +1,906 @@
+builtin.module @calls attributes {
+  
+} {
+
+func.func private @matmul_test.generate_random_matrix(%device: !hal.device, %dim0: i64, %dim1: i64, %element_type: i32, %seed: i32) -> !hal.buffer_view
+func.func private @matmul_test.check_matmul_results(%device: !hal.device, %m: i64, %k: i64, %n: i64, %transpose_rhs: i32, %lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view, %actual_result: !hal.buffer_view)
+
+func.func private @module.matmul_accumulate_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_1x1xbf16_times_1x1xbf16_into_1x1xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_1x1xbf16_times_1x1xbf16_into_1x1xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_2x2xbf16_times_2x2xbf16_into_2x2xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_4x4xbf16_times_4x4xbf16_into_4x4xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_8x8xbf16_times_8x8xbf16_into_8x8xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_9x9xbf16_times_9x9xbf16_into_9x9xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_6x13xbf16_times_13x3xbf16_into_6x3xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_15x37xbf16_times_37x7xbf16_into_15x7xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_81x19xbf16_times_19x41xbf16_into_81x41xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_1x10xbf16_times_10x10xbf16_into_1x10xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_1x10xbf16_times_10x10xbf16_into_1x10xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_10x1xbf16_times_1x10xbf16_into_10x10xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_10x10xbf16_times_10x1xbf16_into_10x1xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_10x10xbf16_times_10x1xbf16_into_10x1xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+
+func.func @matmul_accumulate_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxf32_1_1_1_acc_0() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1x1x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1 : i64
+  %lhs_dim1 = arith.constant 1 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 2 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 3 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 1 : i64
+  %acc_dim1 = arith.constant 1 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 4 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 1 : i64
+  %acc_copy_dim1 = arith.constant 1 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 4 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1 : i64
+  %k = arith.constant 1 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_1x1xbf16_times_1x1xbf16_into_1x1xf32_1_1_1_acc_1() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1x1x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1 : i64
+  %lhs_dim1 = arith.constant 1 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 5 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 6 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 1 : i64
+  %acc_dim1 = arith.constant 1 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 7 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 1 : i64
+  %acc_copy_dim1 = arith.constant 1 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 7 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_1x1xbf16_times_1x1xbf16_into_1x1xf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1 : i64
+  %k = arith.constant 1 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxf32_1_1_1_2() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1x1x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1 : i64
+  %lhs_dim1 = arith.constant 1 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 8 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 9 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1 : i64
+  %k = arith.constant 1 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_1x1xbf16_times_1x1xbf16_into_1x1xf32_1_1_1_3() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1x1x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1 : i64
+  %lhs_dim1 = arith.constant 1 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 10 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 11 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_1x1xbf16_times_1x1xbf16_into_1x1xf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1 : i64
+  %k = arith.constant 1 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxf32_2_2_2_acc_4() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 2x2x2"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 2 : i64
+  %lhs_dim1 = arith.constant 2 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 12 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 2 : i64
+  %rhs_dim1 = arith.constant 2 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 13 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 2 : i64
+  %acc_dim1 = arith.constant 2 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 14 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 2 : i64
+  %acc_copy_dim1 = arith.constant 2 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 14 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 2 : i64
+  %k = arith.constant 2 : i64
+  %n = arith.constant 2 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_2x2xbf16_times_2x2xbf16_into_2x2xf32_2_2_2_acc_5() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 2x2x2"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 2 : i64
+  %lhs_dim1 = arith.constant 2 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 15 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 2 : i64
+  %rhs_dim1 = arith.constant 2 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 16 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 2 : i64
+  %acc_dim1 = arith.constant 2 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 17 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 2 : i64
+  %acc_copy_dim1 = arith.constant 2 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 17 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_2x2xbf16_times_2x2xbf16_into_2x2xf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 2 : i64
+  %k = arith.constant 2 : i64
+  %n = arith.constant 2 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxf32_4_4_4_acc_6() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 4x4x4"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 4 : i64
+  %lhs_dim1 = arith.constant 4 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 18 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 4 : i64
+  %rhs_dim1 = arith.constant 4 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 19 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 4 : i64
+  %acc_dim1 = arith.constant 4 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 20 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 4 : i64
+  %acc_copy_dim1 = arith.constant 4 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 20 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 4 : i64
+  %k = arith.constant 4 : i64
+  %n = arith.constant 4 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_4x4xbf16_times_4x4xbf16_into_4x4xf32_4_4_4_acc_7() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 4x4x4"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 4 : i64
+  %lhs_dim1 = arith.constant 4 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 21 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 4 : i64
+  %rhs_dim1 = arith.constant 4 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 22 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 4 : i64
+  %acc_dim1 = arith.constant 4 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 23 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 4 : i64
+  %acc_copy_dim1 = arith.constant 4 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 23 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_4x4xbf16_times_4x4xbf16_into_4x4xf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 4 : i64
+  %k = arith.constant 4 : i64
+  %n = arith.constant 4 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxf32_8_8_8_acc_8() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 8x8x8"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 8 : i64
+  %lhs_dim1 = arith.constant 8 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 24 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 8 : i64
+  %rhs_dim1 = arith.constant 8 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 25 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 8 : i64
+  %acc_dim1 = arith.constant 8 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 26 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 8 : i64
+  %acc_copy_dim1 = arith.constant 8 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 26 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 8 : i64
+  %k = arith.constant 8 : i64
+  %n = arith.constant 8 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_8x8xbf16_times_8x8xbf16_into_8x8xf32_8_8_8_acc_9() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 8x8x8"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 8 : i64
+  %lhs_dim1 = arith.constant 8 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 27 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 8 : i64
+  %rhs_dim1 = arith.constant 8 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 28 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 8 : i64
+  %acc_dim1 = arith.constant 8 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 29 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 8 : i64
+  %acc_copy_dim1 = arith.constant 8 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 29 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_8x8xbf16_times_8x8xbf16_into_8x8xf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 8 : i64
+  %k = arith.constant 8 : i64
+  %n = arith.constant 8 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxf32_9_9_9_acc_10() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 9x9x9"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 9 : i64
+  %lhs_dim1 = arith.constant 9 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 30 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 9 : i64
+  %rhs_dim1 = arith.constant 9 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 31 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 9 : i64
+  %acc_dim1 = arith.constant 9 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 32 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 9 : i64
+  %acc_copy_dim1 = arith.constant 9 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 32 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 9 : i64
+  %k = arith.constant 9 : i64
+  %n = arith.constant 9 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_9x9xbf16_times_9x9xbf16_into_9x9xf32_9_9_9_acc_11() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 9x9x9"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 9 : i64
+  %lhs_dim1 = arith.constant 9 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 33 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 9 : i64
+  %rhs_dim1 = arith.constant 9 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 34 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 9 : i64
+  %acc_dim1 = arith.constant 9 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 35 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 9 : i64
+  %acc_copy_dim1 = arith.constant 9 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 35 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_9x9xbf16_times_9x9xbf16_into_9x9xf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 9 : i64
+  %k = arith.constant 9 : i64
+  %n = arith.constant 9 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxf32_6_13_3_acc_12() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 6x13x3"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 6 : i64
+  %lhs_dim1 = arith.constant 13 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 36 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 13 : i64
+  %rhs_dim1 = arith.constant 3 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 37 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 6 : i64
+  %acc_dim1 = arith.constant 3 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 38 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 6 : i64
+  %acc_copy_dim1 = arith.constant 3 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 38 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 6 : i64
+  %k = arith.constant 13 : i64
+  %n = arith.constant 3 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_6x13xbf16_times_13x3xbf16_into_6x3xf32_6_13_3_acc_13() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 6x13x3"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 6 : i64
+  %lhs_dim1 = arith.constant 13 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 39 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 13 : i64
+  %rhs_dim1 = arith.constant 3 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 40 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 6 : i64
+  %acc_dim1 = arith.constant 3 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 41 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 6 : i64
+  %acc_copy_dim1 = arith.constant 3 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 41 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_6x13xbf16_times_13x3xbf16_into_6x3xf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 6 : i64
+  %k = arith.constant 13 : i64
+  %n = arith.constant 3 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxf32_15_37_7_14() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 15x37x7"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 15 : i64
+  %lhs_dim1 = arith.constant 37 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 42 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 37 : i64
+  %rhs_dim1 = arith.constant 7 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 43 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 15 : i64
+  %k = arith.constant 37 : i64
+  %n = arith.constant 7 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_15x37xbf16_times_37x7xbf16_into_15x7xf32_15_37_7_15() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 15x37x7"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 15 : i64
+  %lhs_dim1 = arith.constant 37 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 44 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 37 : i64
+  %rhs_dim1 = arith.constant 7 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 45 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_15x37xbf16_times_37x7xbf16_into_15x7xf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 15 : i64
+  %k = arith.constant 37 : i64
+  %n = arith.constant 7 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxf32_81_19_41_acc_16() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 81x19x41"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 81 : i64
+  %lhs_dim1 = arith.constant 19 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 46 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 19 : i64
+  %rhs_dim1 = arith.constant 41 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 47 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 81 : i64
+  %acc_dim1 = arith.constant 41 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 48 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 81 : i64
+  %acc_copy_dim1 = arith.constant 41 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 48 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 81 : i64
+  %k = arith.constant 19 : i64
+  %n = arith.constant 41 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_81x19xbf16_times_19x41xbf16_into_81x41xf32_81_19_41_acc_17() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 81x19x41"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 81 : i64
+  %lhs_dim1 = arith.constant 19 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 49 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 19 : i64
+  %rhs_dim1 = arith.constant 41 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 50 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 81 : i64
+  %acc_dim1 = arith.constant 41 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 51 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 81 : i64
+  %acc_copy_dim1 = arith.constant 41 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 51 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_81x19xbf16_times_19x41xbf16_into_81x41xf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 81 : i64
+  %k = arith.constant 19 : i64
+  %n = arith.constant 41 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxf32_1_10_10_acc_18() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1x10x10"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1 : i64
+  %lhs_dim1 = arith.constant 10 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 52 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 10 : i64
+  %rhs_dim1 = arith.constant 10 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 53 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 1 : i64
+  %acc_dim1 = arith.constant 10 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 54 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 1 : i64
+  %acc_copy_dim1 = arith.constant 10 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 54 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1 : i64
+  %k = arith.constant 10 : i64
+  %n = arith.constant 10 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_1x10xbf16_times_10x10xbf16_into_1x10xf32_1_10_10_acc_19() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1x10x10"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1 : i64
+  %lhs_dim1 = arith.constant 10 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 55 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 10 : i64
+  %rhs_dim1 = arith.constant 10 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 56 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 1 : i64
+  %acc_dim1 = arith.constant 10 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 57 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 1 : i64
+  %acc_copy_dim1 = arith.constant 10 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 57 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_1x10xbf16_times_10x10xbf16_into_1x10xf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1 : i64
+  %k = arith.constant 10 : i64
+  %n = arith.constant 10 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxf32_1_10_10_20() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1x10x10"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1 : i64
+  %lhs_dim1 = arith.constant 10 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 58 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 10 : i64
+  %rhs_dim1 = arith.constant 10 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 59 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1 : i64
+  %k = arith.constant 10 : i64
+  %n = arith.constant 10 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_1x10xbf16_times_10x10xbf16_into_1x10xf32_1_10_10_21() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1x10x10"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1 : i64
+  %lhs_dim1 = arith.constant 10 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 60 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 10 : i64
+  %rhs_dim1 = arith.constant 10 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 61 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_1x10xbf16_times_10x10xbf16_into_1x10xf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1 : i64
+  %k = arith.constant 10 : i64
+  %n = arith.constant 10 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxf32_10_1_10_acc_22() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 10x1x10"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 10 : i64
+  %lhs_dim1 = arith.constant 1 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 62 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1 : i64
+  %rhs_dim1 = arith.constant 10 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 63 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 10 : i64
+  %acc_dim1 = arith.constant 10 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 64 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 10 : i64
+  %acc_copy_dim1 = arith.constant 10 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 64 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 10 : i64
+  %k = arith.constant 1 : i64
+  %n = arith.constant 10 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_10x1xbf16_times_1x10xbf16_into_10x10xf32_10_1_10_acc_23() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 10x1x10"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 10 : i64
+  %lhs_dim1 = arith.constant 1 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 65 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1 : i64
+  %rhs_dim1 = arith.constant 10 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 66 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 10 : i64
+  %acc_dim1 = arith.constant 10 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 67 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 10 : i64
+  %acc_copy_dim1 = arith.constant 10 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 67 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_10x1xbf16_times_1x10xbf16_into_10x10xf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 10 : i64
+  %k = arith.constant 1 : i64
+  %n = arith.constant 10 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxf32_10_10_1_acc_24() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 10x10x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 10 : i64
+  %lhs_dim1 = arith.constant 10 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 68 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 10 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 69 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 10 : i64
+  %acc_dim1 = arith.constant 1 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 70 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 10 : i64
+  %acc_copy_dim1 = arith.constant 1 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 70 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 10 : i64
+  %k = arith.constant 10 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_10x10xbf16_times_10x1xbf16_into_10x1xf32_10_10_1_acc_25() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 10x10x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 10 : i64
+  %lhs_dim1 = arith.constant 10 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 71 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 10 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 72 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 10 : i64
+  %acc_dim1 = arith.constant 1 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 73 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 10 : i64
+  %acc_copy_dim1 = arith.constant 1 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 73 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_10x10xbf16_times_10x1xbf16_into_10x1xf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 10 : i64
+  %k = arith.constant 10 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxf32_10_10_1_26() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 10x10x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 10 : i64
+  %lhs_dim1 = arith.constant 10 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 74 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 10 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 75 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 10 : i64
+  %k = arith.constant 10 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_10x10xbf16_times_10x1xbf16_into_10x1xf32_10_10_1_27() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 10x10x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 10 : i64
+  %lhs_dim1 = arith.constant 10 : i64
+  %lhs_element_type = hal.element_type<bf16> : i32
+  %lhs_seed = arith.constant 76 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 10 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<bf16> : i32
+  %rhs_seed = arith.constant 77 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_10x10xbf16_times_10x1xbf16_into_10x1xf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 10 : i64
+  %k = arith.constant 10 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+
+}

--- a/matmul/tests/generated/matmul_bf16_f32_small_matmul.mlir
+++ b/matmul/tests/generated/matmul_bf16_f32_small_matmul.mlir
@@ -1,0 +1,99 @@
+func.func @matmul_accumulate_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxf32(%lhs: tensor<?x?xbf16>, %rhs: tensor<?x?xbf16>, %acc: tensor<?x?xf32>) -> tensor<?x?xf32> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<?x?xbf16>, tensor<?x?xbf16>) outs(%acc: tensor<?x?xf32>) -> tensor<?x?xf32>
+  return %result: tensor<?x?xf32>
+}
+
+func.func @matmul_accumulate_1x1xbf16_times_1x1xbf16_into_1x1xf32(%lhs: tensor<1x1xbf16>, %rhs: tensor<1x1xbf16>, %acc: tensor<1x1xf32>) -> tensor<1x1xf32> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<1x1xbf16>, tensor<1x1xbf16>) outs(%acc: tensor<1x1xf32>) -> tensor<1x1xf32>
+  return %result: tensor<1x1xf32>
+}
+
+func.func @matmul_DYNxDYNxbf16_times_DYNxDYNxbf16_into_DYNxDYNxf32(%lhs: tensor<?x?xbf16>, %rhs: tensor<?x?xbf16>) -> tensor<?x?xf32> {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %acc_dim0 = tensor.dim %lhs, %c0 : tensor<?x?xbf16>
+  %acc_dim1 = tensor.dim %rhs, %c1 : tensor<?x?xbf16>
+  %init_acc = tensor.empty(%acc_dim0, %acc_dim1) : tensor<?x?xf32>
+  %c0_acc_type = arith.constant 0.0: f32
+  %acc = linalg.fill ins(%c0_acc_type : f32) outs(%init_acc : tensor<?x?xf32>) -> tensor<?x?xf32>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<?x?xbf16>, tensor<?x?xbf16>) outs(%acc: tensor<?x?xf32>) -> tensor<?x?xf32>
+  return %result: tensor<?x?xf32>
+}
+
+func.func @matmul_1x1xbf16_times_1x1xbf16_into_1x1xf32(%lhs: tensor<1x1xbf16>, %rhs: tensor<1x1xbf16>) -> tensor<1x1xf32> {
+  %init_acc = tensor.empty() : tensor<1x1xf32>
+  %c0_acc_type = arith.constant 0.0: f32
+  %acc = linalg.fill ins(%c0_acc_type : f32) outs(%init_acc : tensor<1x1xf32>) -> tensor<1x1xf32>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<1x1xbf16>, tensor<1x1xbf16>) outs(%acc: tensor<1x1xf32>) -> tensor<1x1xf32>
+  return %result: tensor<1x1xf32>
+}
+
+func.func @matmul_accumulate_2x2xbf16_times_2x2xbf16_into_2x2xf32(%lhs: tensor<2x2xbf16>, %rhs: tensor<2x2xbf16>, %acc: tensor<2x2xf32>) -> tensor<2x2xf32> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<2x2xbf16>, tensor<2x2xbf16>) outs(%acc: tensor<2x2xf32>) -> tensor<2x2xf32>
+  return %result: tensor<2x2xf32>
+}
+
+func.func @matmul_accumulate_4x4xbf16_times_4x4xbf16_into_4x4xf32(%lhs: tensor<4x4xbf16>, %rhs: tensor<4x4xbf16>, %acc: tensor<4x4xf32>) -> tensor<4x4xf32> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<4x4xbf16>, tensor<4x4xbf16>) outs(%acc: tensor<4x4xf32>) -> tensor<4x4xf32>
+  return %result: tensor<4x4xf32>
+}
+
+func.func @matmul_accumulate_8x8xbf16_times_8x8xbf16_into_8x8xf32(%lhs: tensor<8x8xbf16>, %rhs: tensor<8x8xbf16>, %acc: tensor<8x8xf32>) -> tensor<8x8xf32> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<8x8xbf16>, tensor<8x8xbf16>) outs(%acc: tensor<8x8xf32>) -> tensor<8x8xf32>
+  return %result: tensor<8x8xf32>
+}
+
+func.func @matmul_accumulate_9x9xbf16_times_9x9xbf16_into_9x9xf32(%lhs: tensor<9x9xbf16>, %rhs: tensor<9x9xbf16>, %acc: tensor<9x9xf32>) -> tensor<9x9xf32> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<9x9xbf16>, tensor<9x9xbf16>) outs(%acc: tensor<9x9xf32>) -> tensor<9x9xf32>
+  return %result: tensor<9x9xf32>
+}
+
+func.func @matmul_accumulate_6x13xbf16_times_13x3xbf16_into_6x3xf32(%lhs: tensor<6x13xbf16>, %rhs: tensor<13x3xbf16>, %acc: tensor<6x3xf32>) -> tensor<6x3xf32> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<6x13xbf16>, tensor<13x3xbf16>) outs(%acc: tensor<6x3xf32>) -> tensor<6x3xf32>
+  return %result: tensor<6x3xf32>
+}
+
+func.func @matmul_15x37xbf16_times_37x7xbf16_into_15x7xf32(%lhs: tensor<15x37xbf16>, %rhs: tensor<37x7xbf16>) -> tensor<15x7xf32> {
+  %init_acc = tensor.empty() : tensor<15x7xf32>
+  %c0_acc_type = arith.constant 0.0: f32
+  %acc = linalg.fill ins(%c0_acc_type : f32) outs(%init_acc : tensor<15x7xf32>) -> tensor<15x7xf32>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<15x37xbf16>, tensor<37x7xbf16>) outs(%acc: tensor<15x7xf32>) -> tensor<15x7xf32>
+  return %result: tensor<15x7xf32>
+}
+
+func.func @matmul_accumulate_81x19xbf16_times_19x41xbf16_into_81x41xf32(%lhs: tensor<81x19xbf16>, %rhs: tensor<19x41xbf16>, %acc: tensor<81x41xf32>) -> tensor<81x41xf32> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<81x19xbf16>, tensor<19x41xbf16>) outs(%acc: tensor<81x41xf32>) -> tensor<81x41xf32>
+  return %result: tensor<81x41xf32>
+}
+
+func.func @matmul_accumulate_1x10xbf16_times_10x10xbf16_into_1x10xf32(%lhs: tensor<1x10xbf16>, %rhs: tensor<10x10xbf16>, %acc: tensor<1x10xf32>) -> tensor<1x10xf32> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<1x10xbf16>, tensor<10x10xbf16>) outs(%acc: tensor<1x10xf32>) -> tensor<1x10xf32>
+  return %result: tensor<1x10xf32>
+}
+
+func.func @matmul_1x10xbf16_times_10x10xbf16_into_1x10xf32(%lhs: tensor<1x10xbf16>, %rhs: tensor<10x10xbf16>) -> tensor<1x10xf32> {
+  %init_acc = tensor.empty() : tensor<1x10xf32>
+  %c0_acc_type = arith.constant 0.0: f32
+  %acc = linalg.fill ins(%c0_acc_type : f32) outs(%init_acc : tensor<1x10xf32>) -> tensor<1x10xf32>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<1x10xbf16>, tensor<10x10xbf16>) outs(%acc: tensor<1x10xf32>) -> tensor<1x10xf32>
+  return %result: tensor<1x10xf32>
+}
+
+func.func @matmul_accumulate_10x1xbf16_times_1x10xbf16_into_10x10xf32(%lhs: tensor<10x1xbf16>, %rhs: tensor<1x10xbf16>, %acc: tensor<10x10xf32>) -> tensor<10x10xf32> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<10x1xbf16>, tensor<1x10xbf16>) outs(%acc: tensor<10x10xf32>) -> tensor<10x10xf32>
+  return %result: tensor<10x10xf32>
+}
+
+func.func @matmul_accumulate_10x10xbf16_times_10x1xbf16_into_10x1xf32(%lhs: tensor<10x10xbf16>, %rhs: tensor<10x1xbf16>, %acc: tensor<10x1xf32>) -> tensor<10x1xf32> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<10x10xbf16>, tensor<10x1xbf16>) outs(%acc: tensor<10x1xf32>) -> tensor<10x1xf32>
+  return %result: tensor<10x1xf32>
+}
+
+func.func @matmul_10x10xbf16_times_10x1xbf16_into_10x1xf32(%lhs: tensor<10x10xbf16>, %rhs: tensor<10x1xbf16>) -> tensor<10x1xf32> {
+  %init_acc = tensor.empty() : tensor<10x1xf32>
+  %c0_acc_type = arith.constant 0.0: f32
+  %acc = linalg.fill ins(%c0_acc_type : f32) outs(%init_acc : tensor<10x1xf32>) -> tensor<10x1xf32>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<10x10xbf16>, tensor<10x1xbf16>) outs(%acc: tensor<10x1xf32>) -> tensor<10x1xf32>
+  return %result: tensor<10x1xf32>
+}
+

--- a/matmul/tests/generated/matmul_f16_f16_gpu_large_aligned_calls.mlir
+++ b/matmul/tests/generated/matmul_f16_f16_gpu_large_aligned_calls.mlir
@@ -1,0 +1,71 @@
+builtin.module @calls attributes {
+  
+} {
+
+func.func private @matmul_test.generate_random_matrix(%device: !hal.device, %dim0: i64, %dim1: i64, %element_type: i32, %seed: i32) -> !hal.buffer_view
+func.func private @matmul_test.check_matmul_results(%device: !hal.device, %m: i64, %k: i64, %n: i64, %transpose_rhs: i32, %lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view, %actual_result: !hal.buffer_view)
+
+func.func private @module.matmul_accumulate_512x128xf16_times_128x512xf16_into_512x512xf16(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_512x128xf16_times_128x512xf16_into_512x512xf16(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+
+func.func @matmul_accumulate_512x128xf16_times_128x512xf16_into_512x512xf16_512_128_512_acc_0() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 512x128x512"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 512 : i64
+  %lhs_dim1 = arith.constant 128 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 2 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 128 : i64
+  %rhs_dim1 = arith.constant 512 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 3 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 512 : i64
+  %acc_dim1 = arith.constant 512 : i64
+  %acc_element_type = hal.element_type<f16> : i32
+  %acc_seed = arith.constant 4 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 512 : i64
+  %acc_copy_dim1 = arith.constant 512 : i64
+  %acc_copy_element_type = hal.element_type<f16> : i32
+  %acc_copy_seed = arith.constant 4 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_512x128xf16_times_128x512xf16_into_512x512xf16(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 512 : i64
+  %k = arith.constant 128 : i64
+  %n = arith.constant 512 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_512x128xf16_times_128x512xf16_into_512x512xf16_512_128_512_1() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 512x128x512"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 512 : i64
+  %lhs_dim1 = arith.constant 128 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 5 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 128 : i64
+  %rhs_dim1 = arith.constant 512 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 6 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_512x128xf16_times_128x512xf16_into_512x512xf16(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 512 : i64
+  %k = arith.constant 128 : i64
+  %n = arith.constant 512 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+
+}

--- a/matmul/tests/generated/matmul_f16_f16_gpu_large_aligned_matmul.mlir
+++ b/matmul/tests/generated/matmul_f16_f16_gpu_large_aligned_matmul.mlir
@@ -1,0 +1,13 @@
+func.func @matmul_accumulate_512x128xf16_times_128x512xf16_into_512x512xf16(%lhs: tensor<512x128xf16>, %rhs: tensor<128x512xf16>, %acc: tensor<512x512xf16>) -> tensor<512x512xf16> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<512x128xf16>, tensor<128x512xf16>) outs(%acc: tensor<512x512xf16>) -> tensor<512x512xf16>
+  return %result: tensor<512x512xf16>
+}
+
+func.func @matmul_512x128xf16_times_128x512xf16_into_512x512xf16(%lhs: tensor<512x128xf16>, %rhs: tensor<128x512xf16>) -> tensor<512x512xf16> {
+  %init_acc = tensor.empty() : tensor<512x512xf16>
+  %c0_acc_type = arith.constant 0.0: f16
+  %acc = linalg.fill ins(%c0_acc_type : f16) outs(%init_acc : tensor<512x512xf16>) -> tensor<512x512xf16>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<512x128xf16>, tensor<128x512xf16>) outs(%acc: tensor<512x512xf16>) -> tensor<512x512xf16>
+  return %result: tensor<512x512xf16>
+}
+

--- a/matmul/tests/generated/matmul_f16_f16_gpu_large_calls.mlir
+++ b/matmul/tests/generated/matmul_f16_f16_gpu_large_calls.mlir
@@ -1,0 +1,270 @@
+builtin.module @calls attributes {
+  
+} {
+
+func.func private @matmul_test.generate_random_matrix(%device: !hal.device, %dim0: i64, %dim1: i64, %element_type: i32, %seed: i32) -> !hal.buffer_view
+func.func private @matmul_test.check_matmul_results(%device: !hal.device, %m: i64, %k: i64, %n: i64, %transpose_rhs: i32, %lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view, %actual_result: !hal.buffer_view)
+
+func.func private @module.matmul_457x330xf16_times_330x512xf16_into_457x512xf16(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_457x330xf16_times_330x514xf16_into_457x514xf16(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_438x330xf16_times_330x514xf16_into_438x514xf16(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_540x332xf16_times_332x516xf16_into_540x516xf16(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_1000x4xf16_times_4x512xf16_into_1000x512xf16(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_4x1000xf16_times_1000x512xf16_into_4x512xf16(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_512x1000xf16_times_1000x4xf16_into_512x4xf16(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_512x128xf16_times_128x500xf16_into_512x500xf16(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_457x160xf16_times_160x512xf16_into_457x512xf16(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_512x330xf16_times_330x512xf16_into_512x512xf16(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+
+func.func @matmul_457x330xf16_times_330x512xf16_into_457x512xf16_457_330_512_0() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 457x330x512"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 457 : i64
+  %lhs_dim1 = arith.constant 330 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 2 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 330 : i64
+  %rhs_dim1 = arith.constant 512 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 3 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_457x330xf16_times_330x512xf16_into_457x512xf16(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 457 : i64
+  %k = arith.constant 330 : i64
+  %n = arith.constant 512 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_457x330xf16_times_330x514xf16_into_457x514xf16_457_330_514_1() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 457x330x514"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 457 : i64
+  %lhs_dim1 = arith.constant 330 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 4 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 330 : i64
+  %rhs_dim1 = arith.constant 514 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 5 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_457x330xf16_times_330x514xf16_into_457x514xf16(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 457 : i64
+  %k = arith.constant 330 : i64
+  %n = arith.constant 514 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_438x330xf16_times_330x514xf16_into_438x514xf16_438_330_514_2() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 438x330x514"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 438 : i64
+  %lhs_dim1 = arith.constant 330 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 6 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 330 : i64
+  %rhs_dim1 = arith.constant 514 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 7 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_438x330xf16_times_330x514xf16_into_438x514xf16(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 438 : i64
+  %k = arith.constant 330 : i64
+  %n = arith.constant 514 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_540x332xf16_times_332x516xf16_into_540x516xf16_540_332_516_3() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 540x332x516"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 540 : i64
+  %lhs_dim1 = arith.constant 332 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 8 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 332 : i64
+  %rhs_dim1 = arith.constant 516 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 9 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_540x332xf16_times_332x516xf16_into_540x516xf16(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 540 : i64
+  %k = arith.constant 332 : i64
+  %n = arith.constant 516 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_1000x4xf16_times_4x512xf16_into_1000x512xf16_1000_4_512_4() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1000x4x512"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1000 : i64
+  %lhs_dim1 = arith.constant 4 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 10 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 4 : i64
+  %rhs_dim1 = arith.constant 512 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 11 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_1000x4xf16_times_4x512xf16_into_1000x512xf16(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1000 : i64
+  %k = arith.constant 4 : i64
+  %n = arith.constant 512 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_4x1000xf16_times_1000x512xf16_into_4x512xf16_4_1000_512_5() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 4x1000x512"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 4 : i64
+  %lhs_dim1 = arith.constant 1000 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 12 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1000 : i64
+  %rhs_dim1 = arith.constant 512 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 13 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_4x1000xf16_times_1000x512xf16_into_4x512xf16(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 4 : i64
+  %k = arith.constant 1000 : i64
+  %n = arith.constant 512 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_512x1000xf16_times_1000x4xf16_into_512x4xf16_512_1000_4_6() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 512x1000x4"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 512 : i64
+  %lhs_dim1 = arith.constant 1000 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 14 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1000 : i64
+  %rhs_dim1 = arith.constant 4 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 15 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_512x1000xf16_times_1000x4xf16_into_512x4xf16(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 512 : i64
+  %k = arith.constant 1000 : i64
+  %n = arith.constant 4 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_512x128xf16_times_128x500xf16_into_512x500xf16_512_128_500_7() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 512x128x500"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 512 : i64
+  %lhs_dim1 = arith.constant 128 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 16 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 128 : i64
+  %rhs_dim1 = arith.constant 500 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 17 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_512x128xf16_times_128x500xf16_into_512x500xf16(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 512 : i64
+  %k = arith.constant 128 : i64
+  %n = arith.constant 500 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_457x160xf16_times_160x512xf16_into_457x512xf16_457_160_512_8() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 457x160x512"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 457 : i64
+  %lhs_dim1 = arith.constant 160 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 18 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 160 : i64
+  %rhs_dim1 = arith.constant 512 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 19 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_457x160xf16_times_160x512xf16_into_457x512xf16(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 457 : i64
+  %k = arith.constant 160 : i64
+  %n = arith.constant 512 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_512x330xf16_times_330x512xf16_into_512x512xf16_512_330_512_9() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 512x330x512"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 512 : i64
+  %lhs_dim1 = arith.constant 330 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 20 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 330 : i64
+  %rhs_dim1 = arith.constant 512 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 21 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_512x330xf16_times_330x512xf16_into_512x512xf16(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 512 : i64
+  %k = arith.constant 330 : i64
+  %n = arith.constant 512 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+
+}

--- a/matmul/tests/generated/matmul_f16_f16_gpu_large_matmul.mlir
+++ b/matmul/tests/generated/matmul_f16_f16_gpu_large_matmul.mlir
@@ -1,0 +1,80 @@
+func.func @matmul_457x330xf16_times_330x512xf16_into_457x512xf16(%lhs: tensor<457x330xf16>, %rhs: tensor<330x512xf16>) -> tensor<457x512xf16> {
+  %init_acc = tensor.empty() : tensor<457x512xf16>
+  %c0_acc_type = arith.constant 0.0: f16
+  %acc = linalg.fill ins(%c0_acc_type : f16) outs(%init_acc : tensor<457x512xf16>) -> tensor<457x512xf16>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<457x330xf16>, tensor<330x512xf16>) outs(%acc: tensor<457x512xf16>) -> tensor<457x512xf16>
+  return %result: tensor<457x512xf16>
+}
+
+func.func @matmul_457x330xf16_times_330x514xf16_into_457x514xf16(%lhs: tensor<457x330xf16>, %rhs: tensor<330x514xf16>) -> tensor<457x514xf16> {
+  %init_acc = tensor.empty() : tensor<457x514xf16>
+  %c0_acc_type = arith.constant 0.0: f16
+  %acc = linalg.fill ins(%c0_acc_type : f16) outs(%init_acc : tensor<457x514xf16>) -> tensor<457x514xf16>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<457x330xf16>, tensor<330x514xf16>) outs(%acc: tensor<457x514xf16>) -> tensor<457x514xf16>
+  return %result: tensor<457x514xf16>
+}
+
+func.func @matmul_438x330xf16_times_330x514xf16_into_438x514xf16(%lhs: tensor<438x330xf16>, %rhs: tensor<330x514xf16>) -> tensor<438x514xf16> {
+  %init_acc = tensor.empty() : tensor<438x514xf16>
+  %c0_acc_type = arith.constant 0.0: f16
+  %acc = linalg.fill ins(%c0_acc_type : f16) outs(%init_acc : tensor<438x514xf16>) -> tensor<438x514xf16>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<438x330xf16>, tensor<330x514xf16>) outs(%acc: tensor<438x514xf16>) -> tensor<438x514xf16>
+  return %result: tensor<438x514xf16>
+}
+
+func.func @matmul_540x332xf16_times_332x516xf16_into_540x516xf16(%lhs: tensor<540x332xf16>, %rhs: tensor<332x516xf16>) -> tensor<540x516xf16> {
+  %init_acc = tensor.empty() : tensor<540x516xf16>
+  %c0_acc_type = arith.constant 0.0: f16
+  %acc = linalg.fill ins(%c0_acc_type : f16) outs(%init_acc : tensor<540x516xf16>) -> tensor<540x516xf16>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<540x332xf16>, tensor<332x516xf16>) outs(%acc: tensor<540x516xf16>) -> tensor<540x516xf16>
+  return %result: tensor<540x516xf16>
+}
+
+func.func @matmul_1000x4xf16_times_4x512xf16_into_1000x512xf16(%lhs: tensor<1000x4xf16>, %rhs: tensor<4x512xf16>) -> tensor<1000x512xf16> {
+  %init_acc = tensor.empty() : tensor<1000x512xf16>
+  %c0_acc_type = arith.constant 0.0: f16
+  %acc = linalg.fill ins(%c0_acc_type : f16) outs(%init_acc : tensor<1000x512xf16>) -> tensor<1000x512xf16>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<1000x4xf16>, tensor<4x512xf16>) outs(%acc: tensor<1000x512xf16>) -> tensor<1000x512xf16>
+  return %result: tensor<1000x512xf16>
+}
+
+func.func @matmul_4x1000xf16_times_1000x512xf16_into_4x512xf16(%lhs: tensor<4x1000xf16>, %rhs: tensor<1000x512xf16>) -> tensor<4x512xf16> {
+  %init_acc = tensor.empty() : tensor<4x512xf16>
+  %c0_acc_type = arith.constant 0.0: f16
+  %acc = linalg.fill ins(%c0_acc_type : f16) outs(%init_acc : tensor<4x512xf16>) -> tensor<4x512xf16>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<4x1000xf16>, tensor<1000x512xf16>) outs(%acc: tensor<4x512xf16>) -> tensor<4x512xf16>
+  return %result: tensor<4x512xf16>
+}
+
+func.func @matmul_512x1000xf16_times_1000x4xf16_into_512x4xf16(%lhs: tensor<512x1000xf16>, %rhs: tensor<1000x4xf16>) -> tensor<512x4xf16> {
+  %init_acc = tensor.empty() : tensor<512x4xf16>
+  %c0_acc_type = arith.constant 0.0: f16
+  %acc = linalg.fill ins(%c0_acc_type : f16) outs(%init_acc : tensor<512x4xf16>) -> tensor<512x4xf16>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<512x1000xf16>, tensor<1000x4xf16>) outs(%acc: tensor<512x4xf16>) -> tensor<512x4xf16>
+  return %result: tensor<512x4xf16>
+}
+
+func.func @matmul_512x128xf16_times_128x500xf16_into_512x500xf16(%lhs: tensor<512x128xf16>, %rhs: tensor<128x500xf16>) -> tensor<512x500xf16> {
+  %init_acc = tensor.empty() : tensor<512x500xf16>
+  %c0_acc_type = arith.constant 0.0: f16
+  %acc = linalg.fill ins(%c0_acc_type : f16) outs(%init_acc : tensor<512x500xf16>) -> tensor<512x500xf16>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<512x128xf16>, tensor<128x500xf16>) outs(%acc: tensor<512x500xf16>) -> tensor<512x500xf16>
+  return %result: tensor<512x500xf16>
+}
+
+func.func @matmul_457x160xf16_times_160x512xf16_into_457x512xf16(%lhs: tensor<457x160xf16>, %rhs: tensor<160x512xf16>) -> tensor<457x512xf16> {
+  %init_acc = tensor.empty() : tensor<457x512xf16>
+  %c0_acc_type = arith.constant 0.0: f16
+  %acc = linalg.fill ins(%c0_acc_type : f16) outs(%init_acc : tensor<457x512xf16>) -> tensor<457x512xf16>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<457x160xf16>, tensor<160x512xf16>) outs(%acc: tensor<457x512xf16>) -> tensor<457x512xf16>
+  return %result: tensor<457x512xf16>
+}
+
+func.func @matmul_512x330xf16_times_330x512xf16_into_512x512xf16(%lhs: tensor<512x330xf16>, %rhs: tensor<330x512xf16>) -> tensor<512x512xf16> {
+  %init_acc = tensor.empty() : tensor<512x512xf16>
+  %c0_acc_type = arith.constant 0.0: f16
+  %acc = linalg.fill ins(%c0_acc_type : f16) outs(%init_acc : tensor<512x512xf16>) -> tensor<512x512xf16>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<512x330xf16>, tensor<330x512xf16>) outs(%acc: tensor<512x512xf16>) -> tensor<512x512xf16>
+  return %result: tensor<512x512xf16>
+}
+

--- a/matmul/tests/generated/matmul_f16_f16_large_calls.mlir
+++ b/matmul/tests/generated/matmul_f16_f16_large_calls.mlir
@@ -1,0 +1,321 @@
+builtin.module @calls attributes {
+  
+} {
+
+func.func private @matmul_test.generate_random_matrix(%device: !hal.device, %dim0: i64, %dim1: i64, %element_type: i32, %seed: i32) -> !hal.buffer_view
+func.func private @matmul_test.check_matmul_results(%device: !hal.device, %m: i64, %k: i64, %n: i64, %transpose_rhs: i32, %lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view, %actual_result: !hal.buffer_view)
+
+func.func private @module.matmul_accumulate_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf16(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_123x456xf16_times_456x789xf16_into_123x789xf16(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf16(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_654x321xf16_times_321x234xf16_into_654x234xf16(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_1x1000xf16_times_1000x1000xf16_into_1x1000xf16(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_1000x1000xf16_times_1000x1xf16_into_1000x1xf16(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_1000x1000xf16_times_1000x1xf16_into_1000x1xf16(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+
+func.func @matmul_accumulate_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf16_123_456_789_acc_0() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 123x456x789"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 123 : i64
+  %lhs_dim1 = arith.constant 456 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 2 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 456 : i64
+  %rhs_dim1 = arith.constant 789 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 3 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 123 : i64
+  %acc_dim1 = arith.constant 789 : i64
+  %acc_element_type = hal.element_type<f16> : i32
+  %acc_seed = arith.constant 4 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 123 : i64
+  %acc_copy_dim1 = arith.constant 789 : i64
+  %acc_copy_element_type = hal.element_type<f16> : i32
+  %acc_copy_seed = arith.constant 4 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf16(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 123 : i64
+  %k = arith.constant 456 : i64
+  %n = arith.constant 789 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_123x456xf16_times_456x789xf16_into_123x789xf16_123_456_789_acc_1() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 123x456x789"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 123 : i64
+  %lhs_dim1 = arith.constant 456 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 5 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 456 : i64
+  %rhs_dim1 = arith.constant 789 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 6 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 123 : i64
+  %acc_dim1 = arith.constant 789 : i64
+  %acc_element_type = hal.element_type<f16> : i32
+  %acc_seed = arith.constant 7 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 123 : i64
+  %acc_copy_dim1 = arith.constant 789 : i64
+  %acc_copy_element_type = hal.element_type<f16> : i32
+  %acc_copy_seed = arith.constant 7 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_123x456xf16_times_456x789xf16_into_123x789xf16(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 123 : i64
+  %k = arith.constant 456 : i64
+  %n = arith.constant 789 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf16_654_321_234_2() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 654x321x234"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 654 : i64
+  %lhs_dim1 = arith.constant 321 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 8 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 321 : i64
+  %rhs_dim1 = arith.constant 234 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 9 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf16(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 654 : i64
+  %k = arith.constant 321 : i64
+  %n = arith.constant 234 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_654x321xf16_times_321x234xf16_into_654x234xf16_654_321_234_3() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 654x321x234"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 654 : i64
+  %lhs_dim1 = arith.constant 321 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 10 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 321 : i64
+  %rhs_dim1 = arith.constant 234 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 11 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_654x321xf16_times_321x234xf16_into_654x234xf16(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 654 : i64
+  %k = arith.constant 321 : i64
+  %n = arith.constant 234 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf16_1_1000_1000_acc_4() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1x1000x1000"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1 : i64
+  %lhs_dim1 = arith.constant 1000 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 12 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1000 : i64
+  %rhs_dim1 = arith.constant 1000 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 13 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 1 : i64
+  %acc_dim1 = arith.constant 1000 : i64
+  %acc_element_type = hal.element_type<f16> : i32
+  %acc_seed = arith.constant 14 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 1 : i64
+  %acc_copy_dim1 = arith.constant 1000 : i64
+  %acc_copy_element_type = hal.element_type<f16> : i32
+  %acc_copy_seed = arith.constant 14 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf16(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1 : i64
+  %k = arith.constant 1000 : i64
+  %n = arith.constant 1000 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_1x1000xf16_times_1000x1000xf16_into_1x1000xf16_1_1000_1000_acc_5() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1x1000x1000"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1 : i64
+  %lhs_dim1 = arith.constant 1000 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 15 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1000 : i64
+  %rhs_dim1 = arith.constant 1000 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 16 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 1 : i64
+  %acc_dim1 = arith.constant 1000 : i64
+  %acc_element_type = hal.element_type<f16> : i32
+  %acc_seed = arith.constant 17 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 1 : i64
+  %acc_copy_dim1 = arith.constant 1000 : i64
+  %acc_copy_element_type = hal.element_type<f16> : i32
+  %acc_copy_seed = arith.constant 17 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_1x1000xf16_times_1000x1000xf16_into_1x1000xf16(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1 : i64
+  %k = arith.constant 1000 : i64
+  %n = arith.constant 1000 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf16_1000_1000_1_acc_6() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1000x1000x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1000 : i64
+  %lhs_dim1 = arith.constant 1000 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 18 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1000 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 19 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 1000 : i64
+  %acc_dim1 = arith.constant 1 : i64
+  %acc_element_type = hal.element_type<f16> : i32
+  %acc_seed = arith.constant 20 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 1000 : i64
+  %acc_copy_dim1 = arith.constant 1 : i64
+  %acc_copy_element_type = hal.element_type<f16> : i32
+  %acc_copy_seed = arith.constant 20 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf16(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1000 : i64
+  %k = arith.constant 1000 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_1000x1000xf16_times_1000x1xf16_into_1000x1xf16_1000_1000_1_acc_7() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1000x1000x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1000 : i64
+  %lhs_dim1 = arith.constant 1000 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 21 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1000 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 22 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 1000 : i64
+  %acc_dim1 = arith.constant 1 : i64
+  %acc_element_type = hal.element_type<f16> : i32
+  %acc_seed = arith.constant 23 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 1000 : i64
+  %acc_copy_dim1 = arith.constant 1 : i64
+  %acc_copy_element_type = hal.element_type<f16> : i32
+  %acc_copy_seed = arith.constant 23 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_1000x1000xf16_times_1000x1xf16_into_1000x1xf16(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1000 : i64
+  %k = arith.constant 1000 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf16_1000_1000_1_8() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1000x1000x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1000 : i64
+  %lhs_dim1 = arith.constant 1000 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 24 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1000 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 25 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf16(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1000 : i64
+  %k = arith.constant 1000 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_1000x1000xf16_times_1000x1xf16_into_1000x1xf16_1000_1000_1_9() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1000x1000x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1000 : i64
+  %lhs_dim1 = arith.constant 1000 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 26 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1000 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 27 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_1000x1000xf16_times_1000x1xf16_into_1000x1xf16(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1000 : i64
+  %k = arith.constant 1000 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+
+}

--- a/matmul/tests/generated/matmul_f16_f16_large_matmul.mlir
+++ b/matmul/tests/generated/matmul_f16_f16_large_matmul.mlir
@@ -1,0 +1,48 @@
+func.func @matmul_accumulate_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf16(%lhs: tensor<?x?xf16>, %rhs: tensor<?x?xf16>, %acc: tensor<?x?xf16>) -> tensor<?x?xf16> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<?x?xf16>, tensor<?x?xf16>) outs(%acc: tensor<?x?xf16>) -> tensor<?x?xf16>
+  return %result: tensor<?x?xf16>
+}
+
+func.func @matmul_accumulate_123x456xf16_times_456x789xf16_into_123x789xf16(%lhs: tensor<123x456xf16>, %rhs: tensor<456x789xf16>, %acc: tensor<123x789xf16>) -> tensor<123x789xf16> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<123x456xf16>, tensor<456x789xf16>) outs(%acc: tensor<123x789xf16>) -> tensor<123x789xf16>
+  return %result: tensor<123x789xf16>
+}
+
+func.func @matmul_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf16(%lhs: tensor<?x?xf16>, %rhs: tensor<?x?xf16>) -> tensor<?x?xf16> {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %acc_dim0 = tensor.dim %lhs, %c0 : tensor<?x?xf16>
+  %acc_dim1 = tensor.dim %rhs, %c1 : tensor<?x?xf16>
+  %init_acc = tensor.empty(%acc_dim0, %acc_dim1) : tensor<?x?xf16>
+  %c0_acc_type = arith.constant 0.0: f16
+  %acc = linalg.fill ins(%c0_acc_type : f16) outs(%init_acc : tensor<?x?xf16>) -> tensor<?x?xf16>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<?x?xf16>, tensor<?x?xf16>) outs(%acc: tensor<?x?xf16>) -> tensor<?x?xf16>
+  return %result: tensor<?x?xf16>
+}
+
+func.func @matmul_654x321xf16_times_321x234xf16_into_654x234xf16(%lhs: tensor<654x321xf16>, %rhs: tensor<321x234xf16>) -> tensor<654x234xf16> {
+  %init_acc = tensor.empty() : tensor<654x234xf16>
+  %c0_acc_type = arith.constant 0.0: f16
+  %acc = linalg.fill ins(%c0_acc_type : f16) outs(%init_acc : tensor<654x234xf16>) -> tensor<654x234xf16>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<654x321xf16>, tensor<321x234xf16>) outs(%acc: tensor<654x234xf16>) -> tensor<654x234xf16>
+  return %result: tensor<654x234xf16>
+}
+
+func.func @matmul_accumulate_1x1000xf16_times_1000x1000xf16_into_1x1000xf16(%lhs: tensor<1x1000xf16>, %rhs: tensor<1000x1000xf16>, %acc: tensor<1x1000xf16>) -> tensor<1x1000xf16> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<1x1000xf16>, tensor<1000x1000xf16>) outs(%acc: tensor<1x1000xf16>) -> tensor<1x1000xf16>
+  return %result: tensor<1x1000xf16>
+}
+
+func.func @matmul_accumulate_1000x1000xf16_times_1000x1xf16_into_1000x1xf16(%lhs: tensor<1000x1000xf16>, %rhs: tensor<1000x1xf16>, %acc: tensor<1000x1xf16>) -> tensor<1000x1xf16> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<1000x1000xf16>, tensor<1000x1xf16>) outs(%acc: tensor<1000x1xf16>) -> tensor<1000x1xf16>
+  return %result: tensor<1000x1xf16>
+}
+
+func.func @matmul_1000x1000xf16_times_1000x1xf16_into_1000x1xf16(%lhs: tensor<1000x1000xf16>, %rhs: tensor<1000x1xf16>) -> tensor<1000x1xf16> {
+  %init_acc = tensor.empty() : tensor<1000x1xf16>
+  %c0_acc_type = arith.constant 0.0: f16
+  %acc = linalg.fill ins(%c0_acc_type : f16) outs(%init_acc : tensor<1000x1xf16>) -> tensor<1000x1xf16>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<1000x1000xf16>, tensor<1000x1xf16>) outs(%acc: tensor<1000x1xf16>) -> tensor<1000x1xf16>
+  return %result: tensor<1000x1xf16>
+}
+

--- a/matmul/tests/generated/matmul_f16_f16_small_calls.mlir
+++ b/matmul/tests/generated/matmul_f16_f16_small_calls.mlir
@@ -1,0 +1,906 @@
+builtin.module @calls attributes {
+  
+} {
+
+func.func private @matmul_test.generate_random_matrix(%device: !hal.device, %dim0: i64, %dim1: i64, %element_type: i32, %seed: i32) -> !hal.buffer_view
+func.func private @matmul_test.check_matmul_results(%device: !hal.device, %m: i64, %k: i64, %n: i64, %transpose_rhs: i32, %lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view, %actual_result: !hal.buffer_view)
+
+func.func private @module.matmul_accumulate_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf16(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_1x1xf16_times_1x1xf16_into_1x1xf16(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf16(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_1x1xf16_times_1x1xf16_into_1x1xf16(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_2x2xf16_times_2x2xf16_into_2x2xf16(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_4x4xf16_times_4x4xf16_into_4x4xf16(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_8x8xf16_times_8x8xf16_into_8x8xf16(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_9x9xf16_times_9x9xf16_into_9x9xf16(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_6x13xf16_times_13x3xf16_into_6x3xf16(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_15x37xf16_times_37x7xf16_into_15x7xf16(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_81x19xf16_times_19x41xf16_into_81x41xf16(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_1x10xf16_times_10x10xf16_into_1x10xf16(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_1x10xf16_times_10x10xf16_into_1x10xf16(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_10x1xf16_times_1x10xf16_into_10x10xf16(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_10x10xf16_times_10x1xf16_into_10x1xf16(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_10x10xf16_times_10x1xf16_into_10x1xf16(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+
+func.func @matmul_accumulate_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf16_1_1_1_acc_0() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1x1x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1 : i64
+  %lhs_dim1 = arith.constant 1 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 2 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 3 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 1 : i64
+  %acc_dim1 = arith.constant 1 : i64
+  %acc_element_type = hal.element_type<f16> : i32
+  %acc_seed = arith.constant 4 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 1 : i64
+  %acc_copy_dim1 = arith.constant 1 : i64
+  %acc_copy_element_type = hal.element_type<f16> : i32
+  %acc_copy_seed = arith.constant 4 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf16(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1 : i64
+  %k = arith.constant 1 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_1x1xf16_times_1x1xf16_into_1x1xf16_1_1_1_acc_1() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1x1x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1 : i64
+  %lhs_dim1 = arith.constant 1 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 5 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 6 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 1 : i64
+  %acc_dim1 = arith.constant 1 : i64
+  %acc_element_type = hal.element_type<f16> : i32
+  %acc_seed = arith.constant 7 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 1 : i64
+  %acc_copy_dim1 = arith.constant 1 : i64
+  %acc_copy_element_type = hal.element_type<f16> : i32
+  %acc_copy_seed = arith.constant 7 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_1x1xf16_times_1x1xf16_into_1x1xf16(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1 : i64
+  %k = arith.constant 1 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf16_1_1_1_2() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1x1x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1 : i64
+  %lhs_dim1 = arith.constant 1 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 8 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 9 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf16(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1 : i64
+  %k = arith.constant 1 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_1x1xf16_times_1x1xf16_into_1x1xf16_1_1_1_3() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1x1x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1 : i64
+  %lhs_dim1 = arith.constant 1 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 10 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 11 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_1x1xf16_times_1x1xf16_into_1x1xf16(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1 : i64
+  %k = arith.constant 1 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf16_2_2_2_acc_4() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 2x2x2"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 2 : i64
+  %lhs_dim1 = arith.constant 2 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 12 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 2 : i64
+  %rhs_dim1 = arith.constant 2 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 13 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 2 : i64
+  %acc_dim1 = arith.constant 2 : i64
+  %acc_element_type = hal.element_type<f16> : i32
+  %acc_seed = arith.constant 14 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 2 : i64
+  %acc_copy_dim1 = arith.constant 2 : i64
+  %acc_copy_element_type = hal.element_type<f16> : i32
+  %acc_copy_seed = arith.constant 14 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf16(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 2 : i64
+  %k = arith.constant 2 : i64
+  %n = arith.constant 2 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_2x2xf16_times_2x2xf16_into_2x2xf16_2_2_2_acc_5() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 2x2x2"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 2 : i64
+  %lhs_dim1 = arith.constant 2 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 15 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 2 : i64
+  %rhs_dim1 = arith.constant 2 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 16 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 2 : i64
+  %acc_dim1 = arith.constant 2 : i64
+  %acc_element_type = hal.element_type<f16> : i32
+  %acc_seed = arith.constant 17 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 2 : i64
+  %acc_copy_dim1 = arith.constant 2 : i64
+  %acc_copy_element_type = hal.element_type<f16> : i32
+  %acc_copy_seed = arith.constant 17 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_2x2xf16_times_2x2xf16_into_2x2xf16(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 2 : i64
+  %k = arith.constant 2 : i64
+  %n = arith.constant 2 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf16_4_4_4_acc_6() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 4x4x4"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 4 : i64
+  %lhs_dim1 = arith.constant 4 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 18 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 4 : i64
+  %rhs_dim1 = arith.constant 4 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 19 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 4 : i64
+  %acc_dim1 = arith.constant 4 : i64
+  %acc_element_type = hal.element_type<f16> : i32
+  %acc_seed = arith.constant 20 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 4 : i64
+  %acc_copy_dim1 = arith.constant 4 : i64
+  %acc_copy_element_type = hal.element_type<f16> : i32
+  %acc_copy_seed = arith.constant 20 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf16(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 4 : i64
+  %k = arith.constant 4 : i64
+  %n = arith.constant 4 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_4x4xf16_times_4x4xf16_into_4x4xf16_4_4_4_acc_7() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 4x4x4"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 4 : i64
+  %lhs_dim1 = arith.constant 4 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 21 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 4 : i64
+  %rhs_dim1 = arith.constant 4 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 22 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 4 : i64
+  %acc_dim1 = arith.constant 4 : i64
+  %acc_element_type = hal.element_type<f16> : i32
+  %acc_seed = arith.constant 23 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 4 : i64
+  %acc_copy_dim1 = arith.constant 4 : i64
+  %acc_copy_element_type = hal.element_type<f16> : i32
+  %acc_copy_seed = arith.constant 23 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_4x4xf16_times_4x4xf16_into_4x4xf16(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 4 : i64
+  %k = arith.constant 4 : i64
+  %n = arith.constant 4 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf16_8_8_8_acc_8() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 8x8x8"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 8 : i64
+  %lhs_dim1 = arith.constant 8 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 24 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 8 : i64
+  %rhs_dim1 = arith.constant 8 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 25 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 8 : i64
+  %acc_dim1 = arith.constant 8 : i64
+  %acc_element_type = hal.element_type<f16> : i32
+  %acc_seed = arith.constant 26 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 8 : i64
+  %acc_copy_dim1 = arith.constant 8 : i64
+  %acc_copy_element_type = hal.element_type<f16> : i32
+  %acc_copy_seed = arith.constant 26 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf16(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 8 : i64
+  %k = arith.constant 8 : i64
+  %n = arith.constant 8 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_8x8xf16_times_8x8xf16_into_8x8xf16_8_8_8_acc_9() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 8x8x8"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 8 : i64
+  %lhs_dim1 = arith.constant 8 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 27 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 8 : i64
+  %rhs_dim1 = arith.constant 8 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 28 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 8 : i64
+  %acc_dim1 = arith.constant 8 : i64
+  %acc_element_type = hal.element_type<f16> : i32
+  %acc_seed = arith.constant 29 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 8 : i64
+  %acc_copy_dim1 = arith.constant 8 : i64
+  %acc_copy_element_type = hal.element_type<f16> : i32
+  %acc_copy_seed = arith.constant 29 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_8x8xf16_times_8x8xf16_into_8x8xf16(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 8 : i64
+  %k = arith.constant 8 : i64
+  %n = arith.constant 8 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf16_9_9_9_acc_10() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 9x9x9"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 9 : i64
+  %lhs_dim1 = arith.constant 9 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 30 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 9 : i64
+  %rhs_dim1 = arith.constant 9 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 31 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 9 : i64
+  %acc_dim1 = arith.constant 9 : i64
+  %acc_element_type = hal.element_type<f16> : i32
+  %acc_seed = arith.constant 32 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 9 : i64
+  %acc_copy_dim1 = arith.constant 9 : i64
+  %acc_copy_element_type = hal.element_type<f16> : i32
+  %acc_copy_seed = arith.constant 32 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf16(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 9 : i64
+  %k = arith.constant 9 : i64
+  %n = arith.constant 9 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_9x9xf16_times_9x9xf16_into_9x9xf16_9_9_9_acc_11() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 9x9x9"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 9 : i64
+  %lhs_dim1 = arith.constant 9 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 33 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 9 : i64
+  %rhs_dim1 = arith.constant 9 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 34 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 9 : i64
+  %acc_dim1 = arith.constant 9 : i64
+  %acc_element_type = hal.element_type<f16> : i32
+  %acc_seed = arith.constant 35 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 9 : i64
+  %acc_copy_dim1 = arith.constant 9 : i64
+  %acc_copy_element_type = hal.element_type<f16> : i32
+  %acc_copy_seed = arith.constant 35 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_9x9xf16_times_9x9xf16_into_9x9xf16(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 9 : i64
+  %k = arith.constant 9 : i64
+  %n = arith.constant 9 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf16_6_13_3_acc_12() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 6x13x3"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 6 : i64
+  %lhs_dim1 = arith.constant 13 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 36 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 13 : i64
+  %rhs_dim1 = arith.constant 3 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 37 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 6 : i64
+  %acc_dim1 = arith.constant 3 : i64
+  %acc_element_type = hal.element_type<f16> : i32
+  %acc_seed = arith.constant 38 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 6 : i64
+  %acc_copy_dim1 = arith.constant 3 : i64
+  %acc_copy_element_type = hal.element_type<f16> : i32
+  %acc_copy_seed = arith.constant 38 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf16(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 6 : i64
+  %k = arith.constant 13 : i64
+  %n = arith.constant 3 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_6x13xf16_times_13x3xf16_into_6x3xf16_6_13_3_acc_13() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 6x13x3"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 6 : i64
+  %lhs_dim1 = arith.constant 13 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 39 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 13 : i64
+  %rhs_dim1 = arith.constant 3 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 40 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 6 : i64
+  %acc_dim1 = arith.constant 3 : i64
+  %acc_element_type = hal.element_type<f16> : i32
+  %acc_seed = arith.constant 41 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 6 : i64
+  %acc_copy_dim1 = arith.constant 3 : i64
+  %acc_copy_element_type = hal.element_type<f16> : i32
+  %acc_copy_seed = arith.constant 41 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_6x13xf16_times_13x3xf16_into_6x3xf16(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 6 : i64
+  %k = arith.constant 13 : i64
+  %n = arith.constant 3 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf16_15_37_7_14() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 15x37x7"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 15 : i64
+  %lhs_dim1 = arith.constant 37 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 42 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 37 : i64
+  %rhs_dim1 = arith.constant 7 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 43 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf16(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 15 : i64
+  %k = arith.constant 37 : i64
+  %n = arith.constant 7 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_15x37xf16_times_37x7xf16_into_15x7xf16_15_37_7_15() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 15x37x7"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 15 : i64
+  %lhs_dim1 = arith.constant 37 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 44 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 37 : i64
+  %rhs_dim1 = arith.constant 7 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 45 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_15x37xf16_times_37x7xf16_into_15x7xf16(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 15 : i64
+  %k = arith.constant 37 : i64
+  %n = arith.constant 7 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf16_81_19_41_acc_16() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 81x19x41"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 81 : i64
+  %lhs_dim1 = arith.constant 19 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 46 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 19 : i64
+  %rhs_dim1 = arith.constant 41 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 47 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 81 : i64
+  %acc_dim1 = arith.constant 41 : i64
+  %acc_element_type = hal.element_type<f16> : i32
+  %acc_seed = arith.constant 48 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 81 : i64
+  %acc_copy_dim1 = arith.constant 41 : i64
+  %acc_copy_element_type = hal.element_type<f16> : i32
+  %acc_copy_seed = arith.constant 48 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf16(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 81 : i64
+  %k = arith.constant 19 : i64
+  %n = arith.constant 41 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_81x19xf16_times_19x41xf16_into_81x41xf16_81_19_41_acc_17() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 81x19x41"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 81 : i64
+  %lhs_dim1 = arith.constant 19 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 49 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 19 : i64
+  %rhs_dim1 = arith.constant 41 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 50 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 81 : i64
+  %acc_dim1 = arith.constant 41 : i64
+  %acc_element_type = hal.element_type<f16> : i32
+  %acc_seed = arith.constant 51 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 81 : i64
+  %acc_copy_dim1 = arith.constant 41 : i64
+  %acc_copy_element_type = hal.element_type<f16> : i32
+  %acc_copy_seed = arith.constant 51 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_81x19xf16_times_19x41xf16_into_81x41xf16(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 81 : i64
+  %k = arith.constant 19 : i64
+  %n = arith.constant 41 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf16_1_10_10_acc_18() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1x10x10"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1 : i64
+  %lhs_dim1 = arith.constant 10 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 52 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 10 : i64
+  %rhs_dim1 = arith.constant 10 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 53 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 1 : i64
+  %acc_dim1 = arith.constant 10 : i64
+  %acc_element_type = hal.element_type<f16> : i32
+  %acc_seed = arith.constant 54 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 1 : i64
+  %acc_copy_dim1 = arith.constant 10 : i64
+  %acc_copy_element_type = hal.element_type<f16> : i32
+  %acc_copy_seed = arith.constant 54 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf16(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1 : i64
+  %k = arith.constant 10 : i64
+  %n = arith.constant 10 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_1x10xf16_times_10x10xf16_into_1x10xf16_1_10_10_acc_19() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1x10x10"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1 : i64
+  %lhs_dim1 = arith.constant 10 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 55 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 10 : i64
+  %rhs_dim1 = arith.constant 10 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 56 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 1 : i64
+  %acc_dim1 = arith.constant 10 : i64
+  %acc_element_type = hal.element_type<f16> : i32
+  %acc_seed = arith.constant 57 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 1 : i64
+  %acc_copy_dim1 = arith.constant 10 : i64
+  %acc_copy_element_type = hal.element_type<f16> : i32
+  %acc_copy_seed = arith.constant 57 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_1x10xf16_times_10x10xf16_into_1x10xf16(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1 : i64
+  %k = arith.constant 10 : i64
+  %n = arith.constant 10 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf16_1_10_10_20() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1x10x10"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1 : i64
+  %lhs_dim1 = arith.constant 10 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 58 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 10 : i64
+  %rhs_dim1 = arith.constant 10 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 59 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf16(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1 : i64
+  %k = arith.constant 10 : i64
+  %n = arith.constant 10 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_1x10xf16_times_10x10xf16_into_1x10xf16_1_10_10_21() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1x10x10"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1 : i64
+  %lhs_dim1 = arith.constant 10 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 60 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 10 : i64
+  %rhs_dim1 = arith.constant 10 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 61 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_1x10xf16_times_10x10xf16_into_1x10xf16(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1 : i64
+  %k = arith.constant 10 : i64
+  %n = arith.constant 10 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf16_10_1_10_acc_22() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 10x1x10"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 10 : i64
+  %lhs_dim1 = arith.constant 1 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 62 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1 : i64
+  %rhs_dim1 = arith.constant 10 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 63 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 10 : i64
+  %acc_dim1 = arith.constant 10 : i64
+  %acc_element_type = hal.element_type<f16> : i32
+  %acc_seed = arith.constant 64 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 10 : i64
+  %acc_copy_dim1 = arith.constant 10 : i64
+  %acc_copy_element_type = hal.element_type<f16> : i32
+  %acc_copy_seed = arith.constant 64 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf16(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 10 : i64
+  %k = arith.constant 1 : i64
+  %n = arith.constant 10 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_10x1xf16_times_1x10xf16_into_10x10xf16_10_1_10_acc_23() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 10x1x10"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 10 : i64
+  %lhs_dim1 = arith.constant 1 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 65 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1 : i64
+  %rhs_dim1 = arith.constant 10 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 66 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 10 : i64
+  %acc_dim1 = arith.constant 10 : i64
+  %acc_element_type = hal.element_type<f16> : i32
+  %acc_seed = arith.constant 67 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 10 : i64
+  %acc_copy_dim1 = arith.constant 10 : i64
+  %acc_copy_element_type = hal.element_type<f16> : i32
+  %acc_copy_seed = arith.constant 67 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_10x1xf16_times_1x10xf16_into_10x10xf16(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 10 : i64
+  %k = arith.constant 1 : i64
+  %n = arith.constant 10 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf16_10_10_1_acc_24() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 10x10x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 10 : i64
+  %lhs_dim1 = arith.constant 10 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 68 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 10 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 69 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 10 : i64
+  %acc_dim1 = arith.constant 1 : i64
+  %acc_element_type = hal.element_type<f16> : i32
+  %acc_seed = arith.constant 70 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 10 : i64
+  %acc_copy_dim1 = arith.constant 1 : i64
+  %acc_copy_element_type = hal.element_type<f16> : i32
+  %acc_copy_seed = arith.constant 70 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf16(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 10 : i64
+  %k = arith.constant 10 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_10x10xf16_times_10x1xf16_into_10x1xf16_10_10_1_acc_25() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 10x10x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 10 : i64
+  %lhs_dim1 = arith.constant 10 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 71 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 10 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 72 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 10 : i64
+  %acc_dim1 = arith.constant 1 : i64
+  %acc_element_type = hal.element_type<f16> : i32
+  %acc_seed = arith.constant 73 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 10 : i64
+  %acc_copy_dim1 = arith.constant 1 : i64
+  %acc_copy_element_type = hal.element_type<f16> : i32
+  %acc_copy_seed = arith.constant 73 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_10x10xf16_times_10x1xf16_into_10x1xf16(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 10 : i64
+  %k = arith.constant 10 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf16_10_10_1_26() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 10x10x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 10 : i64
+  %lhs_dim1 = arith.constant 10 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 74 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 10 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 75 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf16(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 10 : i64
+  %k = arith.constant 10 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_10x10xf16_times_10x1xf16_into_10x1xf16_10_10_1_27() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 10x10x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 10 : i64
+  %lhs_dim1 = arith.constant 10 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 76 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 10 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 77 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_10x10xf16_times_10x1xf16_into_10x1xf16(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 10 : i64
+  %k = arith.constant 10 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+
+}

--- a/matmul/tests/generated/matmul_f16_f16_small_matmul.mlir
+++ b/matmul/tests/generated/matmul_f16_f16_small_matmul.mlir
@@ -1,0 +1,99 @@
+func.func @matmul_accumulate_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf16(%lhs: tensor<?x?xf16>, %rhs: tensor<?x?xf16>, %acc: tensor<?x?xf16>) -> tensor<?x?xf16> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<?x?xf16>, tensor<?x?xf16>) outs(%acc: tensor<?x?xf16>) -> tensor<?x?xf16>
+  return %result: tensor<?x?xf16>
+}
+
+func.func @matmul_accumulate_1x1xf16_times_1x1xf16_into_1x1xf16(%lhs: tensor<1x1xf16>, %rhs: tensor<1x1xf16>, %acc: tensor<1x1xf16>) -> tensor<1x1xf16> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<1x1xf16>, tensor<1x1xf16>) outs(%acc: tensor<1x1xf16>) -> tensor<1x1xf16>
+  return %result: tensor<1x1xf16>
+}
+
+func.func @matmul_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf16(%lhs: tensor<?x?xf16>, %rhs: tensor<?x?xf16>) -> tensor<?x?xf16> {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %acc_dim0 = tensor.dim %lhs, %c0 : tensor<?x?xf16>
+  %acc_dim1 = tensor.dim %rhs, %c1 : tensor<?x?xf16>
+  %init_acc = tensor.empty(%acc_dim0, %acc_dim1) : tensor<?x?xf16>
+  %c0_acc_type = arith.constant 0.0: f16
+  %acc = linalg.fill ins(%c0_acc_type : f16) outs(%init_acc : tensor<?x?xf16>) -> tensor<?x?xf16>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<?x?xf16>, tensor<?x?xf16>) outs(%acc: tensor<?x?xf16>) -> tensor<?x?xf16>
+  return %result: tensor<?x?xf16>
+}
+
+func.func @matmul_1x1xf16_times_1x1xf16_into_1x1xf16(%lhs: tensor<1x1xf16>, %rhs: tensor<1x1xf16>) -> tensor<1x1xf16> {
+  %init_acc = tensor.empty() : tensor<1x1xf16>
+  %c0_acc_type = arith.constant 0.0: f16
+  %acc = linalg.fill ins(%c0_acc_type : f16) outs(%init_acc : tensor<1x1xf16>) -> tensor<1x1xf16>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<1x1xf16>, tensor<1x1xf16>) outs(%acc: tensor<1x1xf16>) -> tensor<1x1xf16>
+  return %result: tensor<1x1xf16>
+}
+
+func.func @matmul_accumulate_2x2xf16_times_2x2xf16_into_2x2xf16(%lhs: tensor<2x2xf16>, %rhs: tensor<2x2xf16>, %acc: tensor<2x2xf16>) -> tensor<2x2xf16> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<2x2xf16>, tensor<2x2xf16>) outs(%acc: tensor<2x2xf16>) -> tensor<2x2xf16>
+  return %result: tensor<2x2xf16>
+}
+
+func.func @matmul_accumulate_4x4xf16_times_4x4xf16_into_4x4xf16(%lhs: tensor<4x4xf16>, %rhs: tensor<4x4xf16>, %acc: tensor<4x4xf16>) -> tensor<4x4xf16> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<4x4xf16>, tensor<4x4xf16>) outs(%acc: tensor<4x4xf16>) -> tensor<4x4xf16>
+  return %result: tensor<4x4xf16>
+}
+
+func.func @matmul_accumulate_8x8xf16_times_8x8xf16_into_8x8xf16(%lhs: tensor<8x8xf16>, %rhs: tensor<8x8xf16>, %acc: tensor<8x8xf16>) -> tensor<8x8xf16> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<8x8xf16>, tensor<8x8xf16>) outs(%acc: tensor<8x8xf16>) -> tensor<8x8xf16>
+  return %result: tensor<8x8xf16>
+}
+
+func.func @matmul_accumulate_9x9xf16_times_9x9xf16_into_9x9xf16(%lhs: tensor<9x9xf16>, %rhs: tensor<9x9xf16>, %acc: tensor<9x9xf16>) -> tensor<9x9xf16> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<9x9xf16>, tensor<9x9xf16>) outs(%acc: tensor<9x9xf16>) -> tensor<9x9xf16>
+  return %result: tensor<9x9xf16>
+}
+
+func.func @matmul_accumulate_6x13xf16_times_13x3xf16_into_6x3xf16(%lhs: tensor<6x13xf16>, %rhs: tensor<13x3xf16>, %acc: tensor<6x3xf16>) -> tensor<6x3xf16> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<6x13xf16>, tensor<13x3xf16>) outs(%acc: tensor<6x3xf16>) -> tensor<6x3xf16>
+  return %result: tensor<6x3xf16>
+}
+
+func.func @matmul_15x37xf16_times_37x7xf16_into_15x7xf16(%lhs: tensor<15x37xf16>, %rhs: tensor<37x7xf16>) -> tensor<15x7xf16> {
+  %init_acc = tensor.empty() : tensor<15x7xf16>
+  %c0_acc_type = arith.constant 0.0: f16
+  %acc = linalg.fill ins(%c0_acc_type : f16) outs(%init_acc : tensor<15x7xf16>) -> tensor<15x7xf16>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<15x37xf16>, tensor<37x7xf16>) outs(%acc: tensor<15x7xf16>) -> tensor<15x7xf16>
+  return %result: tensor<15x7xf16>
+}
+
+func.func @matmul_accumulate_81x19xf16_times_19x41xf16_into_81x41xf16(%lhs: tensor<81x19xf16>, %rhs: tensor<19x41xf16>, %acc: tensor<81x41xf16>) -> tensor<81x41xf16> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<81x19xf16>, tensor<19x41xf16>) outs(%acc: tensor<81x41xf16>) -> tensor<81x41xf16>
+  return %result: tensor<81x41xf16>
+}
+
+func.func @matmul_accumulate_1x10xf16_times_10x10xf16_into_1x10xf16(%lhs: tensor<1x10xf16>, %rhs: tensor<10x10xf16>, %acc: tensor<1x10xf16>) -> tensor<1x10xf16> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<1x10xf16>, tensor<10x10xf16>) outs(%acc: tensor<1x10xf16>) -> tensor<1x10xf16>
+  return %result: tensor<1x10xf16>
+}
+
+func.func @matmul_1x10xf16_times_10x10xf16_into_1x10xf16(%lhs: tensor<1x10xf16>, %rhs: tensor<10x10xf16>) -> tensor<1x10xf16> {
+  %init_acc = tensor.empty() : tensor<1x10xf16>
+  %c0_acc_type = arith.constant 0.0: f16
+  %acc = linalg.fill ins(%c0_acc_type : f16) outs(%init_acc : tensor<1x10xf16>) -> tensor<1x10xf16>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<1x10xf16>, tensor<10x10xf16>) outs(%acc: tensor<1x10xf16>) -> tensor<1x10xf16>
+  return %result: tensor<1x10xf16>
+}
+
+func.func @matmul_accumulate_10x1xf16_times_1x10xf16_into_10x10xf16(%lhs: tensor<10x1xf16>, %rhs: tensor<1x10xf16>, %acc: tensor<10x10xf16>) -> tensor<10x10xf16> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<10x1xf16>, tensor<1x10xf16>) outs(%acc: tensor<10x10xf16>) -> tensor<10x10xf16>
+  return %result: tensor<10x10xf16>
+}
+
+func.func @matmul_accumulate_10x10xf16_times_10x1xf16_into_10x1xf16(%lhs: tensor<10x10xf16>, %rhs: tensor<10x1xf16>, %acc: tensor<10x1xf16>) -> tensor<10x1xf16> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<10x10xf16>, tensor<10x1xf16>) outs(%acc: tensor<10x1xf16>) -> tensor<10x1xf16>
+  return %result: tensor<10x1xf16>
+}
+
+func.func @matmul_10x10xf16_times_10x1xf16_into_10x1xf16(%lhs: tensor<10x10xf16>, %rhs: tensor<10x1xf16>) -> tensor<10x1xf16> {
+  %init_acc = tensor.empty() : tensor<10x1xf16>
+  %c0_acc_type = arith.constant 0.0: f16
+  %acc = linalg.fill ins(%c0_acc_type : f16) outs(%init_acc : tensor<10x1xf16>) -> tensor<10x1xf16>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<10x10xf16>, tensor<10x1xf16>) outs(%acc: tensor<10x1xf16>) -> tensor<10x1xf16>
+  return %result: tensor<10x1xf16>
+}
+

--- a/matmul/tests/generated/matmul_f16_f32_gpu_large_aligned_calls.mlir
+++ b/matmul/tests/generated/matmul_f16_f32_gpu_large_aligned_calls.mlir
@@ -1,0 +1,71 @@
+builtin.module @calls attributes {
+  
+} {
+
+func.func private @matmul_test.generate_random_matrix(%device: !hal.device, %dim0: i64, %dim1: i64, %element_type: i32, %seed: i32) -> !hal.buffer_view
+func.func private @matmul_test.check_matmul_results(%device: !hal.device, %m: i64, %k: i64, %n: i64, %transpose_rhs: i32, %lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view, %actual_result: !hal.buffer_view)
+
+func.func private @module.matmul_accumulate_512x128xf16_times_128x512xf16_into_512x512xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_512x128xf16_times_128x512xf16_into_512x512xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+
+func.func @matmul_accumulate_512x128xf16_times_128x512xf16_into_512x512xf32_512_128_512_acc_0() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 512x128x512"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 512 : i64
+  %lhs_dim1 = arith.constant 128 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 2 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 128 : i64
+  %rhs_dim1 = arith.constant 512 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 3 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 512 : i64
+  %acc_dim1 = arith.constant 512 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 4 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 512 : i64
+  %acc_copy_dim1 = arith.constant 512 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 4 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_512x128xf16_times_128x512xf16_into_512x512xf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 512 : i64
+  %k = arith.constant 128 : i64
+  %n = arith.constant 512 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_512x128xf16_times_128x512xf16_into_512x512xf32_512_128_512_1() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 512x128x512"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 512 : i64
+  %lhs_dim1 = arith.constant 128 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 5 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 128 : i64
+  %rhs_dim1 = arith.constant 512 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 6 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_512x128xf16_times_128x512xf16_into_512x512xf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 512 : i64
+  %k = arith.constant 128 : i64
+  %n = arith.constant 512 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+
+}

--- a/matmul/tests/generated/matmul_f16_f32_gpu_large_aligned_matmul.mlir
+++ b/matmul/tests/generated/matmul_f16_f32_gpu_large_aligned_matmul.mlir
@@ -1,0 +1,13 @@
+func.func @matmul_accumulate_512x128xf16_times_128x512xf16_into_512x512xf32(%lhs: tensor<512x128xf16>, %rhs: tensor<128x512xf16>, %acc: tensor<512x512xf32>) -> tensor<512x512xf32> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<512x128xf16>, tensor<128x512xf16>) outs(%acc: tensor<512x512xf32>) -> tensor<512x512xf32>
+  return %result: tensor<512x512xf32>
+}
+
+func.func @matmul_512x128xf16_times_128x512xf16_into_512x512xf32(%lhs: tensor<512x128xf16>, %rhs: tensor<128x512xf16>) -> tensor<512x512xf32> {
+  %init_acc = tensor.empty() : tensor<512x512xf32>
+  %c0_acc_type = arith.constant 0.0: f32
+  %acc = linalg.fill ins(%c0_acc_type : f32) outs(%init_acc : tensor<512x512xf32>) -> tensor<512x512xf32>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<512x128xf16>, tensor<128x512xf16>) outs(%acc: tensor<512x512xf32>) -> tensor<512x512xf32>
+  return %result: tensor<512x512xf32>
+}
+

--- a/matmul/tests/generated/matmul_f16_f32_gpu_large_calls.mlir
+++ b/matmul/tests/generated/matmul_f16_f32_gpu_large_calls.mlir
@@ -1,0 +1,270 @@
+builtin.module @calls attributes {
+  
+} {
+
+func.func private @matmul_test.generate_random_matrix(%device: !hal.device, %dim0: i64, %dim1: i64, %element_type: i32, %seed: i32) -> !hal.buffer_view
+func.func private @matmul_test.check_matmul_results(%device: !hal.device, %m: i64, %k: i64, %n: i64, %transpose_rhs: i32, %lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view, %actual_result: !hal.buffer_view)
+
+func.func private @module.matmul_457x330xf16_times_330x512xf16_into_457x512xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_457x330xf16_times_330x514xf16_into_457x514xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_438x330xf16_times_330x514xf16_into_438x514xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_540x332xf16_times_332x516xf16_into_540x516xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_1000x4xf16_times_4x512xf16_into_1000x512xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_4x1000xf16_times_1000x512xf16_into_4x512xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_512x1000xf16_times_1000x4xf16_into_512x4xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_512x128xf16_times_128x500xf16_into_512x500xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_457x160xf16_times_160x512xf16_into_457x512xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_512x330xf16_times_330x512xf16_into_512x512xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+
+func.func @matmul_457x330xf16_times_330x512xf16_into_457x512xf32_457_330_512_0() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 457x330x512"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 457 : i64
+  %lhs_dim1 = arith.constant 330 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 2 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 330 : i64
+  %rhs_dim1 = arith.constant 512 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 3 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_457x330xf16_times_330x512xf16_into_457x512xf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 457 : i64
+  %k = arith.constant 330 : i64
+  %n = arith.constant 512 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_457x330xf16_times_330x514xf16_into_457x514xf32_457_330_514_1() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 457x330x514"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 457 : i64
+  %lhs_dim1 = arith.constant 330 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 4 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 330 : i64
+  %rhs_dim1 = arith.constant 514 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 5 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_457x330xf16_times_330x514xf16_into_457x514xf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 457 : i64
+  %k = arith.constant 330 : i64
+  %n = arith.constant 514 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_438x330xf16_times_330x514xf16_into_438x514xf32_438_330_514_2() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 438x330x514"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 438 : i64
+  %lhs_dim1 = arith.constant 330 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 6 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 330 : i64
+  %rhs_dim1 = arith.constant 514 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 7 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_438x330xf16_times_330x514xf16_into_438x514xf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 438 : i64
+  %k = arith.constant 330 : i64
+  %n = arith.constant 514 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_540x332xf16_times_332x516xf16_into_540x516xf32_540_332_516_3() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 540x332x516"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 540 : i64
+  %lhs_dim1 = arith.constant 332 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 8 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 332 : i64
+  %rhs_dim1 = arith.constant 516 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 9 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_540x332xf16_times_332x516xf16_into_540x516xf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 540 : i64
+  %k = arith.constant 332 : i64
+  %n = arith.constant 516 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_1000x4xf16_times_4x512xf16_into_1000x512xf32_1000_4_512_4() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1000x4x512"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1000 : i64
+  %lhs_dim1 = arith.constant 4 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 10 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 4 : i64
+  %rhs_dim1 = arith.constant 512 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 11 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_1000x4xf16_times_4x512xf16_into_1000x512xf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1000 : i64
+  %k = arith.constant 4 : i64
+  %n = arith.constant 512 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_4x1000xf16_times_1000x512xf16_into_4x512xf32_4_1000_512_5() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 4x1000x512"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 4 : i64
+  %lhs_dim1 = arith.constant 1000 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 12 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1000 : i64
+  %rhs_dim1 = arith.constant 512 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 13 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_4x1000xf16_times_1000x512xf16_into_4x512xf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 4 : i64
+  %k = arith.constant 1000 : i64
+  %n = arith.constant 512 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_512x1000xf16_times_1000x4xf16_into_512x4xf32_512_1000_4_6() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 512x1000x4"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 512 : i64
+  %lhs_dim1 = arith.constant 1000 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 14 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1000 : i64
+  %rhs_dim1 = arith.constant 4 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 15 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_512x1000xf16_times_1000x4xf16_into_512x4xf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 512 : i64
+  %k = arith.constant 1000 : i64
+  %n = arith.constant 4 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_512x128xf16_times_128x500xf16_into_512x500xf32_512_128_500_7() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 512x128x500"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 512 : i64
+  %lhs_dim1 = arith.constant 128 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 16 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 128 : i64
+  %rhs_dim1 = arith.constant 500 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 17 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_512x128xf16_times_128x500xf16_into_512x500xf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 512 : i64
+  %k = arith.constant 128 : i64
+  %n = arith.constant 500 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_457x160xf16_times_160x512xf16_into_457x512xf32_457_160_512_8() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 457x160x512"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 457 : i64
+  %lhs_dim1 = arith.constant 160 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 18 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 160 : i64
+  %rhs_dim1 = arith.constant 512 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 19 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_457x160xf16_times_160x512xf16_into_457x512xf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 457 : i64
+  %k = arith.constant 160 : i64
+  %n = arith.constant 512 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_512x330xf16_times_330x512xf16_into_512x512xf32_512_330_512_9() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 512x330x512"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 512 : i64
+  %lhs_dim1 = arith.constant 330 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 20 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 330 : i64
+  %rhs_dim1 = arith.constant 512 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 21 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_512x330xf16_times_330x512xf16_into_512x512xf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 512 : i64
+  %k = arith.constant 330 : i64
+  %n = arith.constant 512 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+
+}

--- a/matmul/tests/generated/matmul_f16_f32_gpu_large_matmul.mlir
+++ b/matmul/tests/generated/matmul_f16_f32_gpu_large_matmul.mlir
@@ -1,0 +1,80 @@
+func.func @matmul_457x330xf16_times_330x512xf16_into_457x512xf32(%lhs: tensor<457x330xf16>, %rhs: tensor<330x512xf16>) -> tensor<457x512xf32> {
+  %init_acc = tensor.empty() : tensor<457x512xf32>
+  %c0_acc_type = arith.constant 0.0: f32
+  %acc = linalg.fill ins(%c0_acc_type : f32) outs(%init_acc : tensor<457x512xf32>) -> tensor<457x512xf32>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<457x330xf16>, tensor<330x512xf16>) outs(%acc: tensor<457x512xf32>) -> tensor<457x512xf32>
+  return %result: tensor<457x512xf32>
+}
+
+func.func @matmul_457x330xf16_times_330x514xf16_into_457x514xf32(%lhs: tensor<457x330xf16>, %rhs: tensor<330x514xf16>) -> tensor<457x514xf32> {
+  %init_acc = tensor.empty() : tensor<457x514xf32>
+  %c0_acc_type = arith.constant 0.0: f32
+  %acc = linalg.fill ins(%c0_acc_type : f32) outs(%init_acc : tensor<457x514xf32>) -> tensor<457x514xf32>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<457x330xf16>, tensor<330x514xf16>) outs(%acc: tensor<457x514xf32>) -> tensor<457x514xf32>
+  return %result: tensor<457x514xf32>
+}
+
+func.func @matmul_438x330xf16_times_330x514xf16_into_438x514xf32(%lhs: tensor<438x330xf16>, %rhs: tensor<330x514xf16>) -> tensor<438x514xf32> {
+  %init_acc = tensor.empty() : tensor<438x514xf32>
+  %c0_acc_type = arith.constant 0.0: f32
+  %acc = linalg.fill ins(%c0_acc_type : f32) outs(%init_acc : tensor<438x514xf32>) -> tensor<438x514xf32>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<438x330xf16>, tensor<330x514xf16>) outs(%acc: tensor<438x514xf32>) -> tensor<438x514xf32>
+  return %result: tensor<438x514xf32>
+}
+
+func.func @matmul_540x332xf16_times_332x516xf16_into_540x516xf32(%lhs: tensor<540x332xf16>, %rhs: tensor<332x516xf16>) -> tensor<540x516xf32> {
+  %init_acc = tensor.empty() : tensor<540x516xf32>
+  %c0_acc_type = arith.constant 0.0: f32
+  %acc = linalg.fill ins(%c0_acc_type : f32) outs(%init_acc : tensor<540x516xf32>) -> tensor<540x516xf32>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<540x332xf16>, tensor<332x516xf16>) outs(%acc: tensor<540x516xf32>) -> tensor<540x516xf32>
+  return %result: tensor<540x516xf32>
+}
+
+func.func @matmul_1000x4xf16_times_4x512xf16_into_1000x512xf32(%lhs: tensor<1000x4xf16>, %rhs: tensor<4x512xf16>) -> tensor<1000x512xf32> {
+  %init_acc = tensor.empty() : tensor<1000x512xf32>
+  %c0_acc_type = arith.constant 0.0: f32
+  %acc = linalg.fill ins(%c0_acc_type : f32) outs(%init_acc : tensor<1000x512xf32>) -> tensor<1000x512xf32>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<1000x4xf16>, tensor<4x512xf16>) outs(%acc: tensor<1000x512xf32>) -> tensor<1000x512xf32>
+  return %result: tensor<1000x512xf32>
+}
+
+func.func @matmul_4x1000xf16_times_1000x512xf16_into_4x512xf32(%lhs: tensor<4x1000xf16>, %rhs: tensor<1000x512xf16>) -> tensor<4x512xf32> {
+  %init_acc = tensor.empty() : tensor<4x512xf32>
+  %c0_acc_type = arith.constant 0.0: f32
+  %acc = linalg.fill ins(%c0_acc_type : f32) outs(%init_acc : tensor<4x512xf32>) -> tensor<4x512xf32>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<4x1000xf16>, tensor<1000x512xf16>) outs(%acc: tensor<4x512xf32>) -> tensor<4x512xf32>
+  return %result: tensor<4x512xf32>
+}
+
+func.func @matmul_512x1000xf16_times_1000x4xf16_into_512x4xf32(%lhs: tensor<512x1000xf16>, %rhs: tensor<1000x4xf16>) -> tensor<512x4xf32> {
+  %init_acc = tensor.empty() : tensor<512x4xf32>
+  %c0_acc_type = arith.constant 0.0: f32
+  %acc = linalg.fill ins(%c0_acc_type : f32) outs(%init_acc : tensor<512x4xf32>) -> tensor<512x4xf32>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<512x1000xf16>, tensor<1000x4xf16>) outs(%acc: tensor<512x4xf32>) -> tensor<512x4xf32>
+  return %result: tensor<512x4xf32>
+}
+
+func.func @matmul_512x128xf16_times_128x500xf16_into_512x500xf32(%lhs: tensor<512x128xf16>, %rhs: tensor<128x500xf16>) -> tensor<512x500xf32> {
+  %init_acc = tensor.empty() : tensor<512x500xf32>
+  %c0_acc_type = arith.constant 0.0: f32
+  %acc = linalg.fill ins(%c0_acc_type : f32) outs(%init_acc : tensor<512x500xf32>) -> tensor<512x500xf32>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<512x128xf16>, tensor<128x500xf16>) outs(%acc: tensor<512x500xf32>) -> tensor<512x500xf32>
+  return %result: tensor<512x500xf32>
+}
+
+func.func @matmul_457x160xf16_times_160x512xf16_into_457x512xf32(%lhs: tensor<457x160xf16>, %rhs: tensor<160x512xf16>) -> tensor<457x512xf32> {
+  %init_acc = tensor.empty() : tensor<457x512xf32>
+  %c0_acc_type = arith.constant 0.0: f32
+  %acc = linalg.fill ins(%c0_acc_type : f32) outs(%init_acc : tensor<457x512xf32>) -> tensor<457x512xf32>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<457x160xf16>, tensor<160x512xf16>) outs(%acc: tensor<457x512xf32>) -> tensor<457x512xf32>
+  return %result: tensor<457x512xf32>
+}
+
+func.func @matmul_512x330xf16_times_330x512xf16_into_512x512xf32(%lhs: tensor<512x330xf16>, %rhs: tensor<330x512xf16>) -> tensor<512x512xf32> {
+  %init_acc = tensor.empty() : tensor<512x512xf32>
+  %c0_acc_type = arith.constant 0.0: f32
+  %acc = linalg.fill ins(%c0_acc_type : f32) outs(%init_acc : tensor<512x512xf32>) -> tensor<512x512xf32>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<512x330xf16>, tensor<330x512xf16>) outs(%acc: tensor<512x512xf32>) -> tensor<512x512xf32>
+  return %result: tensor<512x512xf32>
+}
+

--- a/matmul/tests/generated/matmul_f16_f32_large_calls.mlir
+++ b/matmul/tests/generated/matmul_f16_f32_large_calls.mlir
@@ -1,0 +1,321 @@
+builtin.module @calls attributes {
+  
+} {
+
+func.func private @matmul_test.generate_random_matrix(%device: !hal.device, %dim0: i64, %dim1: i64, %element_type: i32, %seed: i32) -> !hal.buffer_view
+func.func private @matmul_test.check_matmul_results(%device: !hal.device, %m: i64, %k: i64, %n: i64, %transpose_rhs: i32, %lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view, %actual_result: !hal.buffer_view)
+
+func.func private @module.matmul_accumulate_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_123x456xf16_times_456x789xf16_into_123x789xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_654x321xf16_times_321x234xf16_into_654x234xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_1x1000xf16_times_1000x1000xf16_into_1x1000xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_1000x1000xf16_times_1000x1xf16_into_1000x1xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_1000x1000xf16_times_1000x1xf16_into_1000x1xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+
+func.func @matmul_accumulate_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf32_123_456_789_acc_0() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 123x456x789"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 123 : i64
+  %lhs_dim1 = arith.constant 456 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 2 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 456 : i64
+  %rhs_dim1 = arith.constant 789 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 3 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 123 : i64
+  %acc_dim1 = arith.constant 789 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 4 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 123 : i64
+  %acc_copy_dim1 = arith.constant 789 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 4 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 123 : i64
+  %k = arith.constant 456 : i64
+  %n = arith.constant 789 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_123x456xf16_times_456x789xf16_into_123x789xf32_123_456_789_acc_1() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 123x456x789"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 123 : i64
+  %lhs_dim1 = arith.constant 456 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 5 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 456 : i64
+  %rhs_dim1 = arith.constant 789 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 6 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 123 : i64
+  %acc_dim1 = arith.constant 789 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 7 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 123 : i64
+  %acc_copy_dim1 = arith.constant 789 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 7 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_123x456xf16_times_456x789xf16_into_123x789xf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 123 : i64
+  %k = arith.constant 456 : i64
+  %n = arith.constant 789 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf32_654_321_234_2() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 654x321x234"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 654 : i64
+  %lhs_dim1 = arith.constant 321 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 8 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 321 : i64
+  %rhs_dim1 = arith.constant 234 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 9 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 654 : i64
+  %k = arith.constant 321 : i64
+  %n = arith.constant 234 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_654x321xf16_times_321x234xf16_into_654x234xf32_654_321_234_3() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 654x321x234"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 654 : i64
+  %lhs_dim1 = arith.constant 321 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 10 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 321 : i64
+  %rhs_dim1 = arith.constant 234 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 11 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_654x321xf16_times_321x234xf16_into_654x234xf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 654 : i64
+  %k = arith.constant 321 : i64
+  %n = arith.constant 234 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf32_1_1000_1000_acc_4() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1x1000x1000"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1 : i64
+  %lhs_dim1 = arith.constant 1000 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 12 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1000 : i64
+  %rhs_dim1 = arith.constant 1000 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 13 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 1 : i64
+  %acc_dim1 = arith.constant 1000 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 14 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 1 : i64
+  %acc_copy_dim1 = arith.constant 1000 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 14 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1 : i64
+  %k = arith.constant 1000 : i64
+  %n = arith.constant 1000 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_1x1000xf16_times_1000x1000xf16_into_1x1000xf32_1_1000_1000_acc_5() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1x1000x1000"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1 : i64
+  %lhs_dim1 = arith.constant 1000 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 15 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1000 : i64
+  %rhs_dim1 = arith.constant 1000 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 16 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 1 : i64
+  %acc_dim1 = arith.constant 1000 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 17 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 1 : i64
+  %acc_copy_dim1 = arith.constant 1000 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 17 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_1x1000xf16_times_1000x1000xf16_into_1x1000xf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1 : i64
+  %k = arith.constant 1000 : i64
+  %n = arith.constant 1000 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf32_1000_1000_1_acc_6() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1000x1000x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1000 : i64
+  %lhs_dim1 = arith.constant 1000 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 18 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1000 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 19 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 1000 : i64
+  %acc_dim1 = arith.constant 1 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 20 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 1000 : i64
+  %acc_copy_dim1 = arith.constant 1 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 20 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1000 : i64
+  %k = arith.constant 1000 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_1000x1000xf16_times_1000x1xf16_into_1000x1xf32_1000_1000_1_acc_7() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1000x1000x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1000 : i64
+  %lhs_dim1 = arith.constant 1000 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 21 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1000 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 22 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 1000 : i64
+  %acc_dim1 = arith.constant 1 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 23 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 1000 : i64
+  %acc_copy_dim1 = arith.constant 1 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 23 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_1000x1000xf16_times_1000x1xf16_into_1000x1xf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1000 : i64
+  %k = arith.constant 1000 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf32_1000_1000_1_8() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1000x1000x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1000 : i64
+  %lhs_dim1 = arith.constant 1000 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 24 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1000 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 25 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1000 : i64
+  %k = arith.constant 1000 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_1000x1000xf16_times_1000x1xf16_into_1000x1xf32_1000_1000_1_9() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1000x1000x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1000 : i64
+  %lhs_dim1 = arith.constant 1000 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 26 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1000 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 27 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_1000x1000xf16_times_1000x1xf16_into_1000x1xf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1000 : i64
+  %k = arith.constant 1000 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+
+}

--- a/matmul/tests/generated/matmul_f16_f32_large_matmul.mlir
+++ b/matmul/tests/generated/matmul_f16_f32_large_matmul.mlir
@@ -1,0 +1,48 @@
+func.func @matmul_accumulate_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf32(%lhs: tensor<?x?xf16>, %rhs: tensor<?x?xf16>, %acc: tensor<?x?xf32>) -> tensor<?x?xf32> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<?x?xf16>, tensor<?x?xf16>) outs(%acc: tensor<?x?xf32>) -> tensor<?x?xf32>
+  return %result: tensor<?x?xf32>
+}
+
+func.func @matmul_accumulate_123x456xf16_times_456x789xf16_into_123x789xf32(%lhs: tensor<123x456xf16>, %rhs: tensor<456x789xf16>, %acc: tensor<123x789xf32>) -> tensor<123x789xf32> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<123x456xf16>, tensor<456x789xf16>) outs(%acc: tensor<123x789xf32>) -> tensor<123x789xf32>
+  return %result: tensor<123x789xf32>
+}
+
+func.func @matmul_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf32(%lhs: tensor<?x?xf16>, %rhs: tensor<?x?xf16>) -> tensor<?x?xf32> {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %acc_dim0 = tensor.dim %lhs, %c0 : tensor<?x?xf16>
+  %acc_dim1 = tensor.dim %rhs, %c1 : tensor<?x?xf16>
+  %init_acc = tensor.empty(%acc_dim0, %acc_dim1) : tensor<?x?xf32>
+  %c0_acc_type = arith.constant 0.0: f32
+  %acc = linalg.fill ins(%c0_acc_type : f32) outs(%init_acc : tensor<?x?xf32>) -> tensor<?x?xf32>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<?x?xf16>, tensor<?x?xf16>) outs(%acc: tensor<?x?xf32>) -> tensor<?x?xf32>
+  return %result: tensor<?x?xf32>
+}
+
+func.func @matmul_654x321xf16_times_321x234xf16_into_654x234xf32(%lhs: tensor<654x321xf16>, %rhs: tensor<321x234xf16>) -> tensor<654x234xf32> {
+  %init_acc = tensor.empty() : tensor<654x234xf32>
+  %c0_acc_type = arith.constant 0.0: f32
+  %acc = linalg.fill ins(%c0_acc_type : f32) outs(%init_acc : tensor<654x234xf32>) -> tensor<654x234xf32>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<654x321xf16>, tensor<321x234xf16>) outs(%acc: tensor<654x234xf32>) -> tensor<654x234xf32>
+  return %result: tensor<654x234xf32>
+}
+
+func.func @matmul_accumulate_1x1000xf16_times_1000x1000xf16_into_1x1000xf32(%lhs: tensor<1x1000xf16>, %rhs: tensor<1000x1000xf16>, %acc: tensor<1x1000xf32>) -> tensor<1x1000xf32> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<1x1000xf16>, tensor<1000x1000xf16>) outs(%acc: tensor<1x1000xf32>) -> tensor<1x1000xf32>
+  return %result: tensor<1x1000xf32>
+}
+
+func.func @matmul_accumulate_1000x1000xf16_times_1000x1xf16_into_1000x1xf32(%lhs: tensor<1000x1000xf16>, %rhs: tensor<1000x1xf16>, %acc: tensor<1000x1xf32>) -> tensor<1000x1xf32> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<1000x1000xf16>, tensor<1000x1xf16>) outs(%acc: tensor<1000x1xf32>) -> tensor<1000x1xf32>
+  return %result: tensor<1000x1xf32>
+}
+
+func.func @matmul_1000x1000xf16_times_1000x1xf16_into_1000x1xf32(%lhs: tensor<1000x1000xf16>, %rhs: tensor<1000x1xf16>) -> tensor<1000x1xf32> {
+  %init_acc = tensor.empty() : tensor<1000x1xf32>
+  %c0_acc_type = arith.constant 0.0: f32
+  %acc = linalg.fill ins(%c0_acc_type : f32) outs(%init_acc : tensor<1000x1xf32>) -> tensor<1000x1xf32>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<1000x1000xf16>, tensor<1000x1xf16>) outs(%acc: tensor<1000x1xf32>) -> tensor<1000x1xf32>
+  return %result: tensor<1000x1xf32>
+}
+

--- a/matmul/tests/generated/matmul_f16_f32_small_calls.mlir
+++ b/matmul/tests/generated/matmul_f16_f32_small_calls.mlir
@@ -1,0 +1,906 @@
+builtin.module @calls attributes {
+  
+} {
+
+func.func private @matmul_test.generate_random_matrix(%device: !hal.device, %dim0: i64, %dim1: i64, %element_type: i32, %seed: i32) -> !hal.buffer_view
+func.func private @matmul_test.check_matmul_results(%device: !hal.device, %m: i64, %k: i64, %n: i64, %transpose_rhs: i32, %lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view, %actual_result: !hal.buffer_view)
+
+func.func private @module.matmul_accumulate_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_1x1xf16_times_1x1xf16_into_1x1xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_1x1xf16_times_1x1xf16_into_1x1xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_2x2xf16_times_2x2xf16_into_2x2xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_4x4xf16_times_4x4xf16_into_4x4xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_8x8xf16_times_8x8xf16_into_8x8xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_9x9xf16_times_9x9xf16_into_9x9xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_6x13xf16_times_13x3xf16_into_6x3xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_15x37xf16_times_37x7xf16_into_15x7xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_81x19xf16_times_19x41xf16_into_81x41xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_1x10xf16_times_10x10xf16_into_1x10xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_1x10xf16_times_10x10xf16_into_1x10xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_10x1xf16_times_1x10xf16_into_10x10xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_10x10xf16_times_10x1xf16_into_10x1xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_10x10xf16_times_10x1xf16_into_10x1xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+
+func.func @matmul_accumulate_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf32_1_1_1_acc_0() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1x1x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1 : i64
+  %lhs_dim1 = arith.constant 1 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 2 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 3 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 1 : i64
+  %acc_dim1 = arith.constant 1 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 4 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 1 : i64
+  %acc_copy_dim1 = arith.constant 1 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 4 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1 : i64
+  %k = arith.constant 1 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_1x1xf16_times_1x1xf16_into_1x1xf32_1_1_1_acc_1() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1x1x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1 : i64
+  %lhs_dim1 = arith.constant 1 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 5 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 6 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 1 : i64
+  %acc_dim1 = arith.constant 1 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 7 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 1 : i64
+  %acc_copy_dim1 = arith.constant 1 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 7 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_1x1xf16_times_1x1xf16_into_1x1xf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1 : i64
+  %k = arith.constant 1 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf32_1_1_1_2() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1x1x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1 : i64
+  %lhs_dim1 = arith.constant 1 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 8 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 9 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1 : i64
+  %k = arith.constant 1 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_1x1xf16_times_1x1xf16_into_1x1xf32_1_1_1_3() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1x1x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1 : i64
+  %lhs_dim1 = arith.constant 1 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 10 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 11 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_1x1xf16_times_1x1xf16_into_1x1xf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1 : i64
+  %k = arith.constant 1 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf32_2_2_2_acc_4() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 2x2x2"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 2 : i64
+  %lhs_dim1 = arith.constant 2 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 12 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 2 : i64
+  %rhs_dim1 = arith.constant 2 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 13 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 2 : i64
+  %acc_dim1 = arith.constant 2 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 14 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 2 : i64
+  %acc_copy_dim1 = arith.constant 2 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 14 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 2 : i64
+  %k = arith.constant 2 : i64
+  %n = arith.constant 2 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_2x2xf16_times_2x2xf16_into_2x2xf32_2_2_2_acc_5() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 2x2x2"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 2 : i64
+  %lhs_dim1 = arith.constant 2 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 15 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 2 : i64
+  %rhs_dim1 = arith.constant 2 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 16 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 2 : i64
+  %acc_dim1 = arith.constant 2 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 17 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 2 : i64
+  %acc_copy_dim1 = arith.constant 2 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 17 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_2x2xf16_times_2x2xf16_into_2x2xf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 2 : i64
+  %k = arith.constant 2 : i64
+  %n = arith.constant 2 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf32_4_4_4_acc_6() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 4x4x4"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 4 : i64
+  %lhs_dim1 = arith.constant 4 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 18 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 4 : i64
+  %rhs_dim1 = arith.constant 4 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 19 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 4 : i64
+  %acc_dim1 = arith.constant 4 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 20 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 4 : i64
+  %acc_copy_dim1 = arith.constant 4 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 20 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 4 : i64
+  %k = arith.constant 4 : i64
+  %n = arith.constant 4 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_4x4xf16_times_4x4xf16_into_4x4xf32_4_4_4_acc_7() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 4x4x4"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 4 : i64
+  %lhs_dim1 = arith.constant 4 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 21 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 4 : i64
+  %rhs_dim1 = arith.constant 4 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 22 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 4 : i64
+  %acc_dim1 = arith.constant 4 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 23 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 4 : i64
+  %acc_copy_dim1 = arith.constant 4 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 23 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_4x4xf16_times_4x4xf16_into_4x4xf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 4 : i64
+  %k = arith.constant 4 : i64
+  %n = arith.constant 4 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf32_8_8_8_acc_8() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 8x8x8"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 8 : i64
+  %lhs_dim1 = arith.constant 8 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 24 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 8 : i64
+  %rhs_dim1 = arith.constant 8 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 25 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 8 : i64
+  %acc_dim1 = arith.constant 8 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 26 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 8 : i64
+  %acc_copy_dim1 = arith.constant 8 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 26 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 8 : i64
+  %k = arith.constant 8 : i64
+  %n = arith.constant 8 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_8x8xf16_times_8x8xf16_into_8x8xf32_8_8_8_acc_9() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 8x8x8"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 8 : i64
+  %lhs_dim1 = arith.constant 8 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 27 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 8 : i64
+  %rhs_dim1 = arith.constant 8 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 28 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 8 : i64
+  %acc_dim1 = arith.constant 8 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 29 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 8 : i64
+  %acc_copy_dim1 = arith.constant 8 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 29 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_8x8xf16_times_8x8xf16_into_8x8xf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 8 : i64
+  %k = arith.constant 8 : i64
+  %n = arith.constant 8 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf32_9_9_9_acc_10() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 9x9x9"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 9 : i64
+  %lhs_dim1 = arith.constant 9 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 30 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 9 : i64
+  %rhs_dim1 = arith.constant 9 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 31 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 9 : i64
+  %acc_dim1 = arith.constant 9 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 32 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 9 : i64
+  %acc_copy_dim1 = arith.constant 9 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 32 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 9 : i64
+  %k = arith.constant 9 : i64
+  %n = arith.constant 9 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_9x9xf16_times_9x9xf16_into_9x9xf32_9_9_9_acc_11() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 9x9x9"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 9 : i64
+  %lhs_dim1 = arith.constant 9 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 33 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 9 : i64
+  %rhs_dim1 = arith.constant 9 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 34 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 9 : i64
+  %acc_dim1 = arith.constant 9 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 35 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 9 : i64
+  %acc_copy_dim1 = arith.constant 9 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 35 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_9x9xf16_times_9x9xf16_into_9x9xf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 9 : i64
+  %k = arith.constant 9 : i64
+  %n = arith.constant 9 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf32_6_13_3_acc_12() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 6x13x3"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 6 : i64
+  %lhs_dim1 = arith.constant 13 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 36 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 13 : i64
+  %rhs_dim1 = arith.constant 3 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 37 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 6 : i64
+  %acc_dim1 = arith.constant 3 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 38 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 6 : i64
+  %acc_copy_dim1 = arith.constant 3 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 38 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 6 : i64
+  %k = arith.constant 13 : i64
+  %n = arith.constant 3 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_6x13xf16_times_13x3xf16_into_6x3xf32_6_13_3_acc_13() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 6x13x3"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 6 : i64
+  %lhs_dim1 = arith.constant 13 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 39 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 13 : i64
+  %rhs_dim1 = arith.constant 3 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 40 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 6 : i64
+  %acc_dim1 = arith.constant 3 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 41 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 6 : i64
+  %acc_copy_dim1 = arith.constant 3 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 41 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_6x13xf16_times_13x3xf16_into_6x3xf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 6 : i64
+  %k = arith.constant 13 : i64
+  %n = arith.constant 3 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf32_15_37_7_14() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 15x37x7"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 15 : i64
+  %lhs_dim1 = arith.constant 37 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 42 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 37 : i64
+  %rhs_dim1 = arith.constant 7 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 43 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 15 : i64
+  %k = arith.constant 37 : i64
+  %n = arith.constant 7 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_15x37xf16_times_37x7xf16_into_15x7xf32_15_37_7_15() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 15x37x7"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 15 : i64
+  %lhs_dim1 = arith.constant 37 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 44 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 37 : i64
+  %rhs_dim1 = arith.constant 7 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 45 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_15x37xf16_times_37x7xf16_into_15x7xf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 15 : i64
+  %k = arith.constant 37 : i64
+  %n = arith.constant 7 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf32_81_19_41_acc_16() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 81x19x41"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 81 : i64
+  %lhs_dim1 = arith.constant 19 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 46 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 19 : i64
+  %rhs_dim1 = arith.constant 41 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 47 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 81 : i64
+  %acc_dim1 = arith.constant 41 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 48 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 81 : i64
+  %acc_copy_dim1 = arith.constant 41 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 48 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 81 : i64
+  %k = arith.constant 19 : i64
+  %n = arith.constant 41 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_81x19xf16_times_19x41xf16_into_81x41xf32_81_19_41_acc_17() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 81x19x41"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 81 : i64
+  %lhs_dim1 = arith.constant 19 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 49 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 19 : i64
+  %rhs_dim1 = arith.constant 41 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 50 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 81 : i64
+  %acc_dim1 = arith.constant 41 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 51 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 81 : i64
+  %acc_copy_dim1 = arith.constant 41 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 51 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_81x19xf16_times_19x41xf16_into_81x41xf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 81 : i64
+  %k = arith.constant 19 : i64
+  %n = arith.constant 41 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf32_1_10_10_acc_18() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1x10x10"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1 : i64
+  %lhs_dim1 = arith.constant 10 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 52 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 10 : i64
+  %rhs_dim1 = arith.constant 10 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 53 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 1 : i64
+  %acc_dim1 = arith.constant 10 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 54 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 1 : i64
+  %acc_copy_dim1 = arith.constant 10 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 54 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1 : i64
+  %k = arith.constant 10 : i64
+  %n = arith.constant 10 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_1x10xf16_times_10x10xf16_into_1x10xf32_1_10_10_acc_19() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1x10x10"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1 : i64
+  %lhs_dim1 = arith.constant 10 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 55 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 10 : i64
+  %rhs_dim1 = arith.constant 10 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 56 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 1 : i64
+  %acc_dim1 = arith.constant 10 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 57 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 1 : i64
+  %acc_copy_dim1 = arith.constant 10 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 57 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_1x10xf16_times_10x10xf16_into_1x10xf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1 : i64
+  %k = arith.constant 10 : i64
+  %n = arith.constant 10 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf32_1_10_10_20() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1x10x10"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1 : i64
+  %lhs_dim1 = arith.constant 10 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 58 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 10 : i64
+  %rhs_dim1 = arith.constant 10 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 59 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1 : i64
+  %k = arith.constant 10 : i64
+  %n = arith.constant 10 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_1x10xf16_times_10x10xf16_into_1x10xf32_1_10_10_21() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1x10x10"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1 : i64
+  %lhs_dim1 = arith.constant 10 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 60 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 10 : i64
+  %rhs_dim1 = arith.constant 10 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 61 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_1x10xf16_times_10x10xf16_into_1x10xf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1 : i64
+  %k = arith.constant 10 : i64
+  %n = arith.constant 10 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf32_10_1_10_acc_22() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 10x1x10"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 10 : i64
+  %lhs_dim1 = arith.constant 1 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 62 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1 : i64
+  %rhs_dim1 = arith.constant 10 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 63 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 10 : i64
+  %acc_dim1 = arith.constant 10 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 64 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 10 : i64
+  %acc_copy_dim1 = arith.constant 10 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 64 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 10 : i64
+  %k = arith.constant 1 : i64
+  %n = arith.constant 10 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_10x1xf16_times_1x10xf16_into_10x10xf32_10_1_10_acc_23() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 10x1x10"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 10 : i64
+  %lhs_dim1 = arith.constant 1 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 65 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1 : i64
+  %rhs_dim1 = arith.constant 10 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 66 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 10 : i64
+  %acc_dim1 = arith.constant 10 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 67 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 10 : i64
+  %acc_copy_dim1 = arith.constant 10 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 67 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_10x1xf16_times_1x10xf16_into_10x10xf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 10 : i64
+  %k = arith.constant 1 : i64
+  %n = arith.constant 10 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf32_10_10_1_acc_24() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 10x10x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 10 : i64
+  %lhs_dim1 = arith.constant 10 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 68 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 10 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 69 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 10 : i64
+  %acc_dim1 = arith.constant 1 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 70 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 10 : i64
+  %acc_copy_dim1 = arith.constant 1 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 70 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 10 : i64
+  %k = arith.constant 10 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_10x10xf16_times_10x1xf16_into_10x1xf32_10_10_1_acc_25() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 10x10x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 10 : i64
+  %lhs_dim1 = arith.constant 10 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 71 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 10 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 72 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 10 : i64
+  %acc_dim1 = arith.constant 1 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 73 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 10 : i64
+  %acc_copy_dim1 = arith.constant 1 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 73 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_10x10xf16_times_10x1xf16_into_10x1xf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 10 : i64
+  %k = arith.constant 10 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf32_10_10_1_26() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 10x10x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 10 : i64
+  %lhs_dim1 = arith.constant 10 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 74 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 10 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 75 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 10 : i64
+  %k = arith.constant 10 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_10x10xf16_times_10x1xf16_into_10x1xf32_10_10_1_27() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 10x10x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 10 : i64
+  %lhs_dim1 = arith.constant 10 : i64
+  %lhs_element_type = hal.element_type<f16> : i32
+  %lhs_seed = arith.constant 76 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 10 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<f16> : i32
+  %rhs_seed = arith.constant 77 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_10x10xf16_times_10x1xf16_into_10x1xf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 10 : i64
+  %k = arith.constant 10 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+
+}

--- a/matmul/tests/generated/matmul_f16_f32_small_matmul.mlir
+++ b/matmul/tests/generated/matmul_f16_f32_small_matmul.mlir
@@ -1,0 +1,99 @@
+func.func @matmul_accumulate_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf32(%lhs: tensor<?x?xf16>, %rhs: tensor<?x?xf16>, %acc: tensor<?x?xf32>) -> tensor<?x?xf32> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<?x?xf16>, tensor<?x?xf16>) outs(%acc: tensor<?x?xf32>) -> tensor<?x?xf32>
+  return %result: tensor<?x?xf32>
+}
+
+func.func @matmul_accumulate_1x1xf16_times_1x1xf16_into_1x1xf32(%lhs: tensor<1x1xf16>, %rhs: tensor<1x1xf16>, %acc: tensor<1x1xf32>) -> tensor<1x1xf32> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<1x1xf16>, tensor<1x1xf16>) outs(%acc: tensor<1x1xf32>) -> tensor<1x1xf32>
+  return %result: tensor<1x1xf32>
+}
+
+func.func @matmul_DYNxDYNxf16_times_DYNxDYNxf16_into_DYNxDYNxf32(%lhs: tensor<?x?xf16>, %rhs: tensor<?x?xf16>) -> tensor<?x?xf32> {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %acc_dim0 = tensor.dim %lhs, %c0 : tensor<?x?xf16>
+  %acc_dim1 = tensor.dim %rhs, %c1 : tensor<?x?xf16>
+  %init_acc = tensor.empty(%acc_dim0, %acc_dim1) : tensor<?x?xf32>
+  %c0_acc_type = arith.constant 0.0: f32
+  %acc = linalg.fill ins(%c0_acc_type : f32) outs(%init_acc : tensor<?x?xf32>) -> tensor<?x?xf32>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<?x?xf16>, tensor<?x?xf16>) outs(%acc: tensor<?x?xf32>) -> tensor<?x?xf32>
+  return %result: tensor<?x?xf32>
+}
+
+func.func @matmul_1x1xf16_times_1x1xf16_into_1x1xf32(%lhs: tensor<1x1xf16>, %rhs: tensor<1x1xf16>) -> tensor<1x1xf32> {
+  %init_acc = tensor.empty() : tensor<1x1xf32>
+  %c0_acc_type = arith.constant 0.0: f32
+  %acc = linalg.fill ins(%c0_acc_type : f32) outs(%init_acc : tensor<1x1xf32>) -> tensor<1x1xf32>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<1x1xf16>, tensor<1x1xf16>) outs(%acc: tensor<1x1xf32>) -> tensor<1x1xf32>
+  return %result: tensor<1x1xf32>
+}
+
+func.func @matmul_accumulate_2x2xf16_times_2x2xf16_into_2x2xf32(%lhs: tensor<2x2xf16>, %rhs: tensor<2x2xf16>, %acc: tensor<2x2xf32>) -> tensor<2x2xf32> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<2x2xf16>, tensor<2x2xf16>) outs(%acc: tensor<2x2xf32>) -> tensor<2x2xf32>
+  return %result: tensor<2x2xf32>
+}
+
+func.func @matmul_accumulate_4x4xf16_times_4x4xf16_into_4x4xf32(%lhs: tensor<4x4xf16>, %rhs: tensor<4x4xf16>, %acc: tensor<4x4xf32>) -> tensor<4x4xf32> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<4x4xf16>, tensor<4x4xf16>) outs(%acc: tensor<4x4xf32>) -> tensor<4x4xf32>
+  return %result: tensor<4x4xf32>
+}
+
+func.func @matmul_accumulate_8x8xf16_times_8x8xf16_into_8x8xf32(%lhs: tensor<8x8xf16>, %rhs: tensor<8x8xf16>, %acc: tensor<8x8xf32>) -> tensor<8x8xf32> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<8x8xf16>, tensor<8x8xf16>) outs(%acc: tensor<8x8xf32>) -> tensor<8x8xf32>
+  return %result: tensor<8x8xf32>
+}
+
+func.func @matmul_accumulate_9x9xf16_times_9x9xf16_into_9x9xf32(%lhs: tensor<9x9xf16>, %rhs: tensor<9x9xf16>, %acc: tensor<9x9xf32>) -> tensor<9x9xf32> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<9x9xf16>, tensor<9x9xf16>) outs(%acc: tensor<9x9xf32>) -> tensor<9x9xf32>
+  return %result: tensor<9x9xf32>
+}
+
+func.func @matmul_accumulate_6x13xf16_times_13x3xf16_into_6x3xf32(%lhs: tensor<6x13xf16>, %rhs: tensor<13x3xf16>, %acc: tensor<6x3xf32>) -> tensor<6x3xf32> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<6x13xf16>, tensor<13x3xf16>) outs(%acc: tensor<6x3xf32>) -> tensor<6x3xf32>
+  return %result: tensor<6x3xf32>
+}
+
+func.func @matmul_15x37xf16_times_37x7xf16_into_15x7xf32(%lhs: tensor<15x37xf16>, %rhs: tensor<37x7xf16>) -> tensor<15x7xf32> {
+  %init_acc = tensor.empty() : tensor<15x7xf32>
+  %c0_acc_type = arith.constant 0.0: f32
+  %acc = linalg.fill ins(%c0_acc_type : f32) outs(%init_acc : tensor<15x7xf32>) -> tensor<15x7xf32>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<15x37xf16>, tensor<37x7xf16>) outs(%acc: tensor<15x7xf32>) -> tensor<15x7xf32>
+  return %result: tensor<15x7xf32>
+}
+
+func.func @matmul_accumulate_81x19xf16_times_19x41xf16_into_81x41xf32(%lhs: tensor<81x19xf16>, %rhs: tensor<19x41xf16>, %acc: tensor<81x41xf32>) -> tensor<81x41xf32> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<81x19xf16>, tensor<19x41xf16>) outs(%acc: tensor<81x41xf32>) -> tensor<81x41xf32>
+  return %result: tensor<81x41xf32>
+}
+
+func.func @matmul_accumulate_1x10xf16_times_10x10xf16_into_1x10xf32(%lhs: tensor<1x10xf16>, %rhs: tensor<10x10xf16>, %acc: tensor<1x10xf32>) -> tensor<1x10xf32> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<1x10xf16>, tensor<10x10xf16>) outs(%acc: tensor<1x10xf32>) -> tensor<1x10xf32>
+  return %result: tensor<1x10xf32>
+}
+
+func.func @matmul_1x10xf16_times_10x10xf16_into_1x10xf32(%lhs: tensor<1x10xf16>, %rhs: tensor<10x10xf16>) -> tensor<1x10xf32> {
+  %init_acc = tensor.empty() : tensor<1x10xf32>
+  %c0_acc_type = arith.constant 0.0: f32
+  %acc = linalg.fill ins(%c0_acc_type : f32) outs(%init_acc : tensor<1x10xf32>) -> tensor<1x10xf32>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<1x10xf16>, tensor<10x10xf16>) outs(%acc: tensor<1x10xf32>) -> tensor<1x10xf32>
+  return %result: tensor<1x10xf32>
+}
+
+func.func @matmul_accumulate_10x1xf16_times_1x10xf16_into_10x10xf32(%lhs: tensor<10x1xf16>, %rhs: tensor<1x10xf16>, %acc: tensor<10x10xf32>) -> tensor<10x10xf32> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<10x1xf16>, tensor<1x10xf16>) outs(%acc: tensor<10x10xf32>) -> tensor<10x10xf32>
+  return %result: tensor<10x10xf32>
+}
+
+func.func @matmul_accumulate_10x10xf16_times_10x1xf16_into_10x1xf32(%lhs: tensor<10x10xf16>, %rhs: tensor<10x1xf16>, %acc: tensor<10x1xf32>) -> tensor<10x1xf32> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<10x10xf16>, tensor<10x1xf16>) outs(%acc: tensor<10x1xf32>) -> tensor<10x1xf32>
+  return %result: tensor<10x1xf32>
+}
+
+func.func @matmul_10x10xf16_times_10x1xf16_into_10x1xf32(%lhs: tensor<10x10xf16>, %rhs: tensor<10x1xf16>) -> tensor<10x1xf32> {
+  %init_acc = tensor.empty() : tensor<10x1xf32>
+  %c0_acc_type = arith.constant 0.0: f32
+  %acc = linalg.fill ins(%c0_acc_type : f32) outs(%init_acc : tensor<10x1xf32>) -> tensor<10x1xf32>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<10x10xf16>, tensor<10x1xf16>) outs(%acc: tensor<10x1xf32>) -> tensor<10x1xf32>
+  return %result: tensor<10x1xf32>
+}
+

--- a/matmul/tests/generated/matmul_f32_f32_gpu_large_aligned_calls.mlir
+++ b/matmul/tests/generated/matmul_f32_f32_gpu_large_aligned_calls.mlir
@@ -1,0 +1,71 @@
+builtin.module @calls attributes {
+  
+} {
+
+func.func private @matmul_test.generate_random_matrix(%device: !hal.device, %dim0: i64, %dim1: i64, %element_type: i32, %seed: i32) -> !hal.buffer_view
+func.func private @matmul_test.check_matmul_results(%device: !hal.device, %m: i64, %k: i64, %n: i64, %transpose_rhs: i32, %lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view, %actual_result: !hal.buffer_view)
+
+func.func private @module.matmul_accumulate_512x128xf32_times_128x512xf32_into_512x512xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_512x128xf32_times_128x512xf32_into_512x512xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+
+func.func @matmul_accumulate_512x128xf32_times_128x512xf32_into_512x512xf32_512_128_512_acc_0() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 512x128x512"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 512 : i64
+  %lhs_dim1 = arith.constant 128 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 2 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 128 : i64
+  %rhs_dim1 = arith.constant 512 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 3 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 512 : i64
+  %acc_dim1 = arith.constant 512 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 4 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 512 : i64
+  %acc_copy_dim1 = arith.constant 512 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 4 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_512x128xf32_times_128x512xf32_into_512x512xf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 512 : i64
+  %k = arith.constant 128 : i64
+  %n = arith.constant 512 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_512x128xf32_times_128x512xf32_into_512x512xf32_512_128_512_1() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 512x128x512"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 512 : i64
+  %lhs_dim1 = arith.constant 128 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 5 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 128 : i64
+  %rhs_dim1 = arith.constant 512 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 6 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_512x128xf32_times_128x512xf32_into_512x512xf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 512 : i64
+  %k = arith.constant 128 : i64
+  %n = arith.constant 512 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+
+}

--- a/matmul/tests/generated/matmul_f32_f32_gpu_large_aligned_matmul.mlir
+++ b/matmul/tests/generated/matmul_f32_f32_gpu_large_aligned_matmul.mlir
@@ -1,0 +1,13 @@
+func.func @matmul_accumulate_512x128xf32_times_128x512xf32_into_512x512xf32(%lhs: tensor<512x128xf32>, %rhs: tensor<128x512xf32>, %acc: tensor<512x512xf32>) -> tensor<512x512xf32> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<512x128xf32>, tensor<128x512xf32>) outs(%acc: tensor<512x512xf32>) -> tensor<512x512xf32>
+  return %result: tensor<512x512xf32>
+}
+
+func.func @matmul_512x128xf32_times_128x512xf32_into_512x512xf32(%lhs: tensor<512x128xf32>, %rhs: tensor<128x512xf32>) -> tensor<512x512xf32> {
+  %init_acc = tensor.empty() : tensor<512x512xf32>
+  %c0_acc_type = arith.constant 0.0: f32
+  %acc = linalg.fill ins(%c0_acc_type : f32) outs(%init_acc : tensor<512x512xf32>) -> tensor<512x512xf32>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<512x128xf32>, tensor<128x512xf32>) outs(%acc: tensor<512x512xf32>) -> tensor<512x512xf32>
+  return %result: tensor<512x512xf32>
+}
+

--- a/matmul/tests/generated/matmul_f32_f32_gpu_large_calls.mlir
+++ b/matmul/tests/generated/matmul_f32_f32_gpu_large_calls.mlir
@@ -1,0 +1,270 @@
+builtin.module @calls attributes {
+  
+} {
+
+func.func private @matmul_test.generate_random_matrix(%device: !hal.device, %dim0: i64, %dim1: i64, %element_type: i32, %seed: i32) -> !hal.buffer_view
+func.func private @matmul_test.check_matmul_results(%device: !hal.device, %m: i64, %k: i64, %n: i64, %transpose_rhs: i32, %lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view, %actual_result: !hal.buffer_view)
+
+func.func private @module.matmul_457x330xf32_times_330x512xf32_into_457x512xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_457x330xf32_times_330x514xf32_into_457x514xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_438x330xf32_times_330x514xf32_into_438x514xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_540x332xf32_times_332x516xf32_into_540x516xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_1000x4xf32_times_4x512xf32_into_1000x512xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_4x1000xf32_times_1000x512xf32_into_4x512xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_512x1000xf32_times_1000x4xf32_into_512x4xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_512x128xf32_times_128x500xf32_into_512x500xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_457x160xf32_times_160x512xf32_into_457x512xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_512x330xf32_times_330x512xf32_into_512x512xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+
+func.func @matmul_457x330xf32_times_330x512xf32_into_457x512xf32_457_330_512_0() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 457x330x512"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 457 : i64
+  %lhs_dim1 = arith.constant 330 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 2 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 330 : i64
+  %rhs_dim1 = arith.constant 512 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 3 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_457x330xf32_times_330x512xf32_into_457x512xf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 457 : i64
+  %k = arith.constant 330 : i64
+  %n = arith.constant 512 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_457x330xf32_times_330x514xf32_into_457x514xf32_457_330_514_1() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 457x330x514"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 457 : i64
+  %lhs_dim1 = arith.constant 330 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 4 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 330 : i64
+  %rhs_dim1 = arith.constant 514 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 5 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_457x330xf32_times_330x514xf32_into_457x514xf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 457 : i64
+  %k = arith.constant 330 : i64
+  %n = arith.constant 514 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_438x330xf32_times_330x514xf32_into_438x514xf32_438_330_514_2() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 438x330x514"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 438 : i64
+  %lhs_dim1 = arith.constant 330 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 6 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 330 : i64
+  %rhs_dim1 = arith.constant 514 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 7 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_438x330xf32_times_330x514xf32_into_438x514xf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 438 : i64
+  %k = arith.constant 330 : i64
+  %n = arith.constant 514 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_540x332xf32_times_332x516xf32_into_540x516xf32_540_332_516_3() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 540x332x516"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 540 : i64
+  %lhs_dim1 = arith.constant 332 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 8 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 332 : i64
+  %rhs_dim1 = arith.constant 516 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 9 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_540x332xf32_times_332x516xf32_into_540x516xf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 540 : i64
+  %k = arith.constant 332 : i64
+  %n = arith.constant 516 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_1000x4xf32_times_4x512xf32_into_1000x512xf32_1000_4_512_4() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1000x4x512"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1000 : i64
+  %lhs_dim1 = arith.constant 4 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 10 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 4 : i64
+  %rhs_dim1 = arith.constant 512 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 11 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_1000x4xf32_times_4x512xf32_into_1000x512xf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1000 : i64
+  %k = arith.constant 4 : i64
+  %n = arith.constant 512 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_4x1000xf32_times_1000x512xf32_into_4x512xf32_4_1000_512_5() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 4x1000x512"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 4 : i64
+  %lhs_dim1 = arith.constant 1000 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 12 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1000 : i64
+  %rhs_dim1 = arith.constant 512 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 13 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_4x1000xf32_times_1000x512xf32_into_4x512xf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 4 : i64
+  %k = arith.constant 1000 : i64
+  %n = arith.constant 512 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_512x1000xf32_times_1000x4xf32_into_512x4xf32_512_1000_4_6() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 512x1000x4"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 512 : i64
+  %lhs_dim1 = arith.constant 1000 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 14 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1000 : i64
+  %rhs_dim1 = arith.constant 4 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 15 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_512x1000xf32_times_1000x4xf32_into_512x4xf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 512 : i64
+  %k = arith.constant 1000 : i64
+  %n = arith.constant 4 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_512x128xf32_times_128x500xf32_into_512x500xf32_512_128_500_7() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 512x128x500"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 512 : i64
+  %lhs_dim1 = arith.constant 128 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 16 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 128 : i64
+  %rhs_dim1 = arith.constant 500 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 17 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_512x128xf32_times_128x500xf32_into_512x500xf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 512 : i64
+  %k = arith.constant 128 : i64
+  %n = arith.constant 500 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_457x160xf32_times_160x512xf32_into_457x512xf32_457_160_512_8() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 457x160x512"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 457 : i64
+  %lhs_dim1 = arith.constant 160 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 18 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 160 : i64
+  %rhs_dim1 = arith.constant 512 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 19 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_457x160xf32_times_160x512xf32_into_457x512xf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 457 : i64
+  %k = arith.constant 160 : i64
+  %n = arith.constant 512 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_512x330xf32_times_330x512xf32_into_512x512xf32_512_330_512_9() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 512x330x512"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 512 : i64
+  %lhs_dim1 = arith.constant 330 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 20 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 330 : i64
+  %rhs_dim1 = arith.constant 512 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 21 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_512x330xf32_times_330x512xf32_into_512x512xf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 512 : i64
+  %k = arith.constant 330 : i64
+  %n = arith.constant 512 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+
+}

--- a/matmul/tests/generated/matmul_f32_f32_gpu_large_matmul.mlir
+++ b/matmul/tests/generated/matmul_f32_f32_gpu_large_matmul.mlir
@@ -1,0 +1,80 @@
+func.func @matmul_457x330xf32_times_330x512xf32_into_457x512xf32(%lhs: tensor<457x330xf32>, %rhs: tensor<330x512xf32>) -> tensor<457x512xf32> {
+  %init_acc = tensor.empty() : tensor<457x512xf32>
+  %c0_acc_type = arith.constant 0.0: f32
+  %acc = linalg.fill ins(%c0_acc_type : f32) outs(%init_acc : tensor<457x512xf32>) -> tensor<457x512xf32>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<457x330xf32>, tensor<330x512xf32>) outs(%acc: tensor<457x512xf32>) -> tensor<457x512xf32>
+  return %result: tensor<457x512xf32>
+}
+
+func.func @matmul_457x330xf32_times_330x514xf32_into_457x514xf32(%lhs: tensor<457x330xf32>, %rhs: tensor<330x514xf32>) -> tensor<457x514xf32> {
+  %init_acc = tensor.empty() : tensor<457x514xf32>
+  %c0_acc_type = arith.constant 0.0: f32
+  %acc = linalg.fill ins(%c0_acc_type : f32) outs(%init_acc : tensor<457x514xf32>) -> tensor<457x514xf32>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<457x330xf32>, tensor<330x514xf32>) outs(%acc: tensor<457x514xf32>) -> tensor<457x514xf32>
+  return %result: tensor<457x514xf32>
+}
+
+func.func @matmul_438x330xf32_times_330x514xf32_into_438x514xf32(%lhs: tensor<438x330xf32>, %rhs: tensor<330x514xf32>) -> tensor<438x514xf32> {
+  %init_acc = tensor.empty() : tensor<438x514xf32>
+  %c0_acc_type = arith.constant 0.0: f32
+  %acc = linalg.fill ins(%c0_acc_type : f32) outs(%init_acc : tensor<438x514xf32>) -> tensor<438x514xf32>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<438x330xf32>, tensor<330x514xf32>) outs(%acc: tensor<438x514xf32>) -> tensor<438x514xf32>
+  return %result: tensor<438x514xf32>
+}
+
+func.func @matmul_540x332xf32_times_332x516xf32_into_540x516xf32(%lhs: tensor<540x332xf32>, %rhs: tensor<332x516xf32>) -> tensor<540x516xf32> {
+  %init_acc = tensor.empty() : tensor<540x516xf32>
+  %c0_acc_type = arith.constant 0.0: f32
+  %acc = linalg.fill ins(%c0_acc_type : f32) outs(%init_acc : tensor<540x516xf32>) -> tensor<540x516xf32>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<540x332xf32>, tensor<332x516xf32>) outs(%acc: tensor<540x516xf32>) -> tensor<540x516xf32>
+  return %result: tensor<540x516xf32>
+}
+
+func.func @matmul_1000x4xf32_times_4x512xf32_into_1000x512xf32(%lhs: tensor<1000x4xf32>, %rhs: tensor<4x512xf32>) -> tensor<1000x512xf32> {
+  %init_acc = tensor.empty() : tensor<1000x512xf32>
+  %c0_acc_type = arith.constant 0.0: f32
+  %acc = linalg.fill ins(%c0_acc_type : f32) outs(%init_acc : tensor<1000x512xf32>) -> tensor<1000x512xf32>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<1000x4xf32>, tensor<4x512xf32>) outs(%acc: tensor<1000x512xf32>) -> tensor<1000x512xf32>
+  return %result: tensor<1000x512xf32>
+}
+
+func.func @matmul_4x1000xf32_times_1000x512xf32_into_4x512xf32(%lhs: tensor<4x1000xf32>, %rhs: tensor<1000x512xf32>) -> tensor<4x512xf32> {
+  %init_acc = tensor.empty() : tensor<4x512xf32>
+  %c0_acc_type = arith.constant 0.0: f32
+  %acc = linalg.fill ins(%c0_acc_type : f32) outs(%init_acc : tensor<4x512xf32>) -> tensor<4x512xf32>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<4x1000xf32>, tensor<1000x512xf32>) outs(%acc: tensor<4x512xf32>) -> tensor<4x512xf32>
+  return %result: tensor<4x512xf32>
+}
+
+func.func @matmul_512x1000xf32_times_1000x4xf32_into_512x4xf32(%lhs: tensor<512x1000xf32>, %rhs: tensor<1000x4xf32>) -> tensor<512x4xf32> {
+  %init_acc = tensor.empty() : tensor<512x4xf32>
+  %c0_acc_type = arith.constant 0.0: f32
+  %acc = linalg.fill ins(%c0_acc_type : f32) outs(%init_acc : tensor<512x4xf32>) -> tensor<512x4xf32>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<512x1000xf32>, tensor<1000x4xf32>) outs(%acc: tensor<512x4xf32>) -> tensor<512x4xf32>
+  return %result: tensor<512x4xf32>
+}
+
+func.func @matmul_512x128xf32_times_128x500xf32_into_512x500xf32(%lhs: tensor<512x128xf32>, %rhs: tensor<128x500xf32>) -> tensor<512x500xf32> {
+  %init_acc = tensor.empty() : tensor<512x500xf32>
+  %c0_acc_type = arith.constant 0.0: f32
+  %acc = linalg.fill ins(%c0_acc_type : f32) outs(%init_acc : tensor<512x500xf32>) -> tensor<512x500xf32>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<512x128xf32>, tensor<128x500xf32>) outs(%acc: tensor<512x500xf32>) -> tensor<512x500xf32>
+  return %result: tensor<512x500xf32>
+}
+
+func.func @matmul_457x160xf32_times_160x512xf32_into_457x512xf32(%lhs: tensor<457x160xf32>, %rhs: tensor<160x512xf32>) -> tensor<457x512xf32> {
+  %init_acc = tensor.empty() : tensor<457x512xf32>
+  %c0_acc_type = arith.constant 0.0: f32
+  %acc = linalg.fill ins(%c0_acc_type : f32) outs(%init_acc : tensor<457x512xf32>) -> tensor<457x512xf32>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<457x160xf32>, tensor<160x512xf32>) outs(%acc: tensor<457x512xf32>) -> tensor<457x512xf32>
+  return %result: tensor<457x512xf32>
+}
+
+func.func @matmul_512x330xf32_times_330x512xf32_into_512x512xf32(%lhs: tensor<512x330xf32>, %rhs: tensor<330x512xf32>) -> tensor<512x512xf32> {
+  %init_acc = tensor.empty() : tensor<512x512xf32>
+  %c0_acc_type = arith.constant 0.0: f32
+  %acc = linalg.fill ins(%c0_acc_type : f32) outs(%init_acc : tensor<512x512xf32>) -> tensor<512x512xf32>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<512x330xf32>, tensor<330x512xf32>) outs(%acc: tensor<512x512xf32>) -> tensor<512x512xf32>
+  return %result: tensor<512x512xf32>
+}
+

--- a/matmul/tests/generated/matmul_f32_f32_large_calls.mlir
+++ b/matmul/tests/generated/matmul_f32_f32_large_calls.mlir
@@ -1,0 +1,321 @@
+builtin.module @calls attributes {
+  
+} {
+
+func.func private @matmul_test.generate_random_matrix(%device: !hal.device, %dim0: i64, %dim1: i64, %element_type: i32, %seed: i32) -> !hal.buffer_view
+func.func private @matmul_test.check_matmul_results(%device: !hal.device, %m: i64, %k: i64, %n: i64, %transpose_rhs: i32, %lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view, %actual_result: !hal.buffer_view)
+
+func.func private @module.matmul_accumulate_DYNxDYNxf32_times_DYNxDYNxf32_into_DYNxDYNxf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_123x456xf32_times_456x789xf32_into_123x789xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_DYNxDYNxf32_times_DYNxDYNxf32_into_DYNxDYNxf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_654x321xf32_times_321x234xf32_into_654x234xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_1x1000xf32_times_1000x1000xf32_into_1x1000xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_1000x1000xf32_times_1000x1xf32_into_1000x1xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_1000x1000xf32_times_1000x1xf32_into_1000x1xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+
+func.func @matmul_accumulate_DYNxDYNxf32_times_DYNxDYNxf32_into_DYNxDYNxf32_123_456_789_acc_0() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 123x456x789"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 123 : i64
+  %lhs_dim1 = arith.constant 456 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 2 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 456 : i64
+  %rhs_dim1 = arith.constant 789 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 3 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 123 : i64
+  %acc_dim1 = arith.constant 789 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 4 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 123 : i64
+  %acc_copy_dim1 = arith.constant 789 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 4 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxf32_times_DYNxDYNxf32_into_DYNxDYNxf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 123 : i64
+  %k = arith.constant 456 : i64
+  %n = arith.constant 789 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_123x456xf32_times_456x789xf32_into_123x789xf32_123_456_789_acc_1() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 123x456x789"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 123 : i64
+  %lhs_dim1 = arith.constant 456 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 5 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 456 : i64
+  %rhs_dim1 = arith.constant 789 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 6 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 123 : i64
+  %acc_dim1 = arith.constant 789 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 7 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 123 : i64
+  %acc_copy_dim1 = arith.constant 789 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 7 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_123x456xf32_times_456x789xf32_into_123x789xf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 123 : i64
+  %k = arith.constant 456 : i64
+  %n = arith.constant 789 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_DYNxDYNxf32_times_DYNxDYNxf32_into_DYNxDYNxf32_654_321_234_2() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 654x321x234"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 654 : i64
+  %lhs_dim1 = arith.constant 321 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 8 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 321 : i64
+  %rhs_dim1 = arith.constant 234 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 9 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_DYNxDYNxf32_times_DYNxDYNxf32_into_DYNxDYNxf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 654 : i64
+  %k = arith.constant 321 : i64
+  %n = arith.constant 234 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_654x321xf32_times_321x234xf32_into_654x234xf32_654_321_234_3() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 654x321x234"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 654 : i64
+  %lhs_dim1 = arith.constant 321 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 10 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 321 : i64
+  %rhs_dim1 = arith.constant 234 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 11 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_654x321xf32_times_321x234xf32_into_654x234xf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 654 : i64
+  %k = arith.constant 321 : i64
+  %n = arith.constant 234 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_DYNxDYNxf32_times_DYNxDYNxf32_into_DYNxDYNxf32_1_1000_1000_acc_4() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1x1000x1000"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1 : i64
+  %lhs_dim1 = arith.constant 1000 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 12 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1000 : i64
+  %rhs_dim1 = arith.constant 1000 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 13 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 1 : i64
+  %acc_dim1 = arith.constant 1000 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 14 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 1 : i64
+  %acc_copy_dim1 = arith.constant 1000 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 14 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxf32_times_DYNxDYNxf32_into_DYNxDYNxf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1 : i64
+  %k = arith.constant 1000 : i64
+  %n = arith.constant 1000 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_1x1000xf32_times_1000x1000xf32_into_1x1000xf32_1_1000_1000_acc_5() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1x1000x1000"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1 : i64
+  %lhs_dim1 = arith.constant 1000 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 15 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1000 : i64
+  %rhs_dim1 = arith.constant 1000 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 16 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 1 : i64
+  %acc_dim1 = arith.constant 1000 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 17 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 1 : i64
+  %acc_copy_dim1 = arith.constant 1000 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 17 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_1x1000xf32_times_1000x1000xf32_into_1x1000xf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1 : i64
+  %k = arith.constant 1000 : i64
+  %n = arith.constant 1000 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_DYNxDYNxf32_times_DYNxDYNxf32_into_DYNxDYNxf32_1000_1000_1_acc_6() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1000x1000x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1000 : i64
+  %lhs_dim1 = arith.constant 1000 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 18 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1000 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 19 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 1000 : i64
+  %acc_dim1 = arith.constant 1 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 20 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 1000 : i64
+  %acc_copy_dim1 = arith.constant 1 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 20 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxf32_times_DYNxDYNxf32_into_DYNxDYNxf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1000 : i64
+  %k = arith.constant 1000 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_1000x1000xf32_times_1000x1xf32_into_1000x1xf32_1000_1000_1_acc_7() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1000x1000x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1000 : i64
+  %lhs_dim1 = arith.constant 1000 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 21 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1000 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 22 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 1000 : i64
+  %acc_dim1 = arith.constant 1 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 23 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 1000 : i64
+  %acc_copy_dim1 = arith.constant 1 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 23 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_1000x1000xf32_times_1000x1xf32_into_1000x1xf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1000 : i64
+  %k = arith.constant 1000 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_DYNxDYNxf32_times_DYNxDYNxf32_into_DYNxDYNxf32_1000_1000_1_8() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1000x1000x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1000 : i64
+  %lhs_dim1 = arith.constant 1000 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 24 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1000 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 25 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_DYNxDYNxf32_times_DYNxDYNxf32_into_DYNxDYNxf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1000 : i64
+  %k = arith.constant 1000 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_1000x1000xf32_times_1000x1xf32_into_1000x1xf32_1000_1000_1_9() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1000x1000x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1000 : i64
+  %lhs_dim1 = arith.constant 1000 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 26 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1000 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 27 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_1000x1000xf32_times_1000x1xf32_into_1000x1xf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1000 : i64
+  %k = arith.constant 1000 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+
+}

--- a/matmul/tests/generated/matmul_f32_f32_large_matmul.mlir
+++ b/matmul/tests/generated/matmul_f32_f32_large_matmul.mlir
@@ -1,0 +1,48 @@
+func.func @matmul_accumulate_DYNxDYNxf32_times_DYNxDYNxf32_into_DYNxDYNxf32(%lhs: tensor<?x?xf32>, %rhs: tensor<?x?xf32>, %acc: tensor<?x?xf32>) -> tensor<?x?xf32> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<?x?xf32>, tensor<?x?xf32>) outs(%acc: tensor<?x?xf32>) -> tensor<?x?xf32>
+  return %result: tensor<?x?xf32>
+}
+
+func.func @matmul_accumulate_123x456xf32_times_456x789xf32_into_123x789xf32(%lhs: tensor<123x456xf32>, %rhs: tensor<456x789xf32>, %acc: tensor<123x789xf32>) -> tensor<123x789xf32> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<123x456xf32>, tensor<456x789xf32>) outs(%acc: tensor<123x789xf32>) -> tensor<123x789xf32>
+  return %result: tensor<123x789xf32>
+}
+
+func.func @matmul_DYNxDYNxf32_times_DYNxDYNxf32_into_DYNxDYNxf32(%lhs: tensor<?x?xf32>, %rhs: tensor<?x?xf32>) -> tensor<?x?xf32> {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %acc_dim0 = tensor.dim %lhs, %c0 : tensor<?x?xf32>
+  %acc_dim1 = tensor.dim %rhs, %c1 : tensor<?x?xf32>
+  %init_acc = tensor.empty(%acc_dim0, %acc_dim1) : tensor<?x?xf32>
+  %c0_acc_type = arith.constant 0.0: f32
+  %acc = linalg.fill ins(%c0_acc_type : f32) outs(%init_acc : tensor<?x?xf32>) -> tensor<?x?xf32>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<?x?xf32>, tensor<?x?xf32>) outs(%acc: tensor<?x?xf32>) -> tensor<?x?xf32>
+  return %result: tensor<?x?xf32>
+}
+
+func.func @matmul_654x321xf32_times_321x234xf32_into_654x234xf32(%lhs: tensor<654x321xf32>, %rhs: tensor<321x234xf32>) -> tensor<654x234xf32> {
+  %init_acc = tensor.empty() : tensor<654x234xf32>
+  %c0_acc_type = arith.constant 0.0: f32
+  %acc = linalg.fill ins(%c0_acc_type : f32) outs(%init_acc : tensor<654x234xf32>) -> tensor<654x234xf32>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<654x321xf32>, tensor<321x234xf32>) outs(%acc: tensor<654x234xf32>) -> tensor<654x234xf32>
+  return %result: tensor<654x234xf32>
+}
+
+func.func @matmul_accumulate_1x1000xf32_times_1000x1000xf32_into_1x1000xf32(%lhs: tensor<1x1000xf32>, %rhs: tensor<1000x1000xf32>, %acc: tensor<1x1000xf32>) -> tensor<1x1000xf32> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<1x1000xf32>, tensor<1000x1000xf32>) outs(%acc: tensor<1x1000xf32>) -> tensor<1x1000xf32>
+  return %result: tensor<1x1000xf32>
+}
+
+func.func @matmul_accumulate_1000x1000xf32_times_1000x1xf32_into_1000x1xf32(%lhs: tensor<1000x1000xf32>, %rhs: tensor<1000x1xf32>, %acc: tensor<1000x1xf32>) -> tensor<1000x1xf32> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<1000x1000xf32>, tensor<1000x1xf32>) outs(%acc: tensor<1000x1xf32>) -> tensor<1000x1xf32>
+  return %result: tensor<1000x1xf32>
+}
+
+func.func @matmul_1000x1000xf32_times_1000x1xf32_into_1000x1xf32(%lhs: tensor<1000x1000xf32>, %rhs: tensor<1000x1xf32>) -> tensor<1000x1xf32> {
+  %init_acc = tensor.empty() : tensor<1000x1xf32>
+  %c0_acc_type = arith.constant 0.0: f32
+  %acc = linalg.fill ins(%c0_acc_type : f32) outs(%init_acc : tensor<1000x1xf32>) -> tensor<1000x1xf32>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<1000x1000xf32>, tensor<1000x1xf32>) outs(%acc: tensor<1000x1xf32>) -> tensor<1000x1xf32>
+  return %result: tensor<1000x1xf32>
+}
+

--- a/matmul/tests/generated/matmul_f32_f32_small_calls.mlir
+++ b/matmul/tests/generated/matmul_f32_f32_small_calls.mlir
@@ -1,0 +1,906 @@
+builtin.module @calls attributes {
+  
+} {
+
+func.func private @matmul_test.generate_random_matrix(%device: !hal.device, %dim0: i64, %dim1: i64, %element_type: i32, %seed: i32) -> !hal.buffer_view
+func.func private @matmul_test.check_matmul_results(%device: !hal.device, %m: i64, %k: i64, %n: i64, %transpose_rhs: i32, %lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view, %actual_result: !hal.buffer_view)
+
+func.func private @module.matmul_accumulate_DYNxDYNxf32_times_DYNxDYNxf32_into_DYNxDYNxf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_1x1xf32_times_1x1xf32_into_1x1xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_DYNxDYNxf32_times_DYNxDYNxf32_into_DYNxDYNxf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_1x1xf32_times_1x1xf32_into_1x1xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_2x2xf32_times_2x2xf32_into_2x2xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_4x4xf32_times_4x4xf32_into_4x4xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_8x8xf32_times_8x8xf32_into_8x8xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_9x9xf32_times_9x9xf32_into_9x9xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_6x13xf32_times_13x3xf32_into_6x3xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_15x37xf32_times_37x7xf32_into_15x7xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_81x19xf32_times_19x41xf32_into_81x41xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_1x10xf32_times_10x10xf32_into_1x10xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_1x10xf32_times_10x10xf32_into_1x10xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_10x1xf32_times_1x10xf32_into_10x10xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_10x10xf32_times_10x1xf32_into_10x1xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_10x10xf32_times_10x1xf32_into_10x1xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+
+func.func @matmul_accumulate_DYNxDYNxf32_times_DYNxDYNxf32_into_DYNxDYNxf32_1_1_1_acc_0() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1x1x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1 : i64
+  %lhs_dim1 = arith.constant 1 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 2 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 3 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 1 : i64
+  %acc_dim1 = arith.constant 1 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 4 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 1 : i64
+  %acc_copy_dim1 = arith.constant 1 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 4 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxf32_times_DYNxDYNxf32_into_DYNxDYNxf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1 : i64
+  %k = arith.constant 1 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_1x1xf32_times_1x1xf32_into_1x1xf32_1_1_1_acc_1() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1x1x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1 : i64
+  %lhs_dim1 = arith.constant 1 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 5 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 6 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 1 : i64
+  %acc_dim1 = arith.constant 1 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 7 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 1 : i64
+  %acc_copy_dim1 = arith.constant 1 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 7 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_1x1xf32_times_1x1xf32_into_1x1xf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1 : i64
+  %k = arith.constant 1 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_DYNxDYNxf32_times_DYNxDYNxf32_into_DYNxDYNxf32_1_1_1_2() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1x1x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1 : i64
+  %lhs_dim1 = arith.constant 1 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 8 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 9 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_DYNxDYNxf32_times_DYNxDYNxf32_into_DYNxDYNxf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1 : i64
+  %k = arith.constant 1 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_1x1xf32_times_1x1xf32_into_1x1xf32_1_1_1_3() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1x1x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1 : i64
+  %lhs_dim1 = arith.constant 1 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 10 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 11 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_1x1xf32_times_1x1xf32_into_1x1xf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1 : i64
+  %k = arith.constant 1 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_DYNxDYNxf32_times_DYNxDYNxf32_into_DYNxDYNxf32_2_2_2_acc_4() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 2x2x2"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 2 : i64
+  %lhs_dim1 = arith.constant 2 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 12 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 2 : i64
+  %rhs_dim1 = arith.constant 2 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 13 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 2 : i64
+  %acc_dim1 = arith.constant 2 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 14 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 2 : i64
+  %acc_copy_dim1 = arith.constant 2 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 14 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxf32_times_DYNxDYNxf32_into_DYNxDYNxf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 2 : i64
+  %k = arith.constant 2 : i64
+  %n = arith.constant 2 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_2x2xf32_times_2x2xf32_into_2x2xf32_2_2_2_acc_5() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 2x2x2"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 2 : i64
+  %lhs_dim1 = arith.constant 2 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 15 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 2 : i64
+  %rhs_dim1 = arith.constant 2 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 16 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 2 : i64
+  %acc_dim1 = arith.constant 2 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 17 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 2 : i64
+  %acc_copy_dim1 = arith.constant 2 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 17 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_2x2xf32_times_2x2xf32_into_2x2xf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 2 : i64
+  %k = arith.constant 2 : i64
+  %n = arith.constant 2 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_DYNxDYNxf32_times_DYNxDYNxf32_into_DYNxDYNxf32_4_4_4_acc_6() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 4x4x4"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 4 : i64
+  %lhs_dim1 = arith.constant 4 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 18 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 4 : i64
+  %rhs_dim1 = arith.constant 4 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 19 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 4 : i64
+  %acc_dim1 = arith.constant 4 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 20 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 4 : i64
+  %acc_copy_dim1 = arith.constant 4 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 20 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxf32_times_DYNxDYNxf32_into_DYNxDYNxf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 4 : i64
+  %k = arith.constant 4 : i64
+  %n = arith.constant 4 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_4x4xf32_times_4x4xf32_into_4x4xf32_4_4_4_acc_7() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 4x4x4"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 4 : i64
+  %lhs_dim1 = arith.constant 4 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 21 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 4 : i64
+  %rhs_dim1 = arith.constant 4 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 22 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 4 : i64
+  %acc_dim1 = arith.constant 4 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 23 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 4 : i64
+  %acc_copy_dim1 = arith.constant 4 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 23 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_4x4xf32_times_4x4xf32_into_4x4xf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 4 : i64
+  %k = arith.constant 4 : i64
+  %n = arith.constant 4 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_DYNxDYNxf32_times_DYNxDYNxf32_into_DYNxDYNxf32_8_8_8_acc_8() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 8x8x8"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 8 : i64
+  %lhs_dim1 = arith.constant 8 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 24 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 8 : i64
+  %rhs_dim1 = arith.constant 8 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 25 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 8 : i64
+  %acc_dim1 = arith.constant 8 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 26 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 8 : i64
+  %acc_copy_dim1 = arith.constant 8 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 26 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxf32_times_DYNxDYNxf32_into_DYNxDYNxf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 8 : i64
+  %k = arith.constant 8 : i64
+  %n = arith.constant 8 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_8x8xf32_times_8x8xf32_into_8x8xf32_8_8_8_acc_9() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 8x8x8"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 8 : i64
+  %lhs_dim1 = arith.constant 8 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 27 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 8 : i64
+  %rhs_dim1 = arith.constant 8 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 28 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 8 : i64
+  %acc_dim1 = arith.constant 8 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 29 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 8 : i64
+  %acc_copy_dim1 = arith.constant 8 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 29 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_8x8xf32_times_8x8xf32_into_8x8xf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 8 : i64
+  %k = arith.constant 8 : i64
+  %n = arith.constant 8 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_DYNxDYNxf32_times_DYNxDYNxf32_into_DYNxDYNxf32_9_9_9_acc_10() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 9x9x9"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 9 : i64
+  %lhs_dim1 = arith.constant 9 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 30 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 9 : i64
+  %rhs_dim1 = arith.constant 9 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 31 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 9 : i64
+  %acc_dim1 = arith.constant 9 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 32 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 9 : i64
+  %acc_copy_dim1 = arith.constant 9 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 32 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxf32_times_DYNxDYNxf32_into_DYNxDYNxf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 9 : i64
+  %k = arith.constant 9 : i64
+  %n = arith.constant 9 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_9x9xf32_times_9x9xf32_into_9x9xf32_9_9_9_acc_11() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 9x9x9"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 9 : i64
+  %lhs_dim1 = arith.constant 9 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 33 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 9 : i64
+  %rhs_dim1 = arith.constant 9 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 34 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 9 : i64
+  %acc_dim1 = arith.constant 9 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 35 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 9 : i64
+  %acc_copy_dim1 = arith.constant 9 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 35 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_9x9xf32_times_9x9xf32_into_9x9xf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 9 : i64
+  %k = arith.constant 9 : i64
+  %n = arith.constant 9 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_DYNxDYNxf32_times_DYNxDYNxf32_into_DYNxDYNxf32_6_13_3_acc_12() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 6x13x3"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 6 : i64
+  %lhs_dim1 = arith.constant 13 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 36 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 13 : i64
+  %rhs_dim1 = arith.constant 3 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 37 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 6 : i64
+  %acc_dim1 = arith.constant 3 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 38 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 6 : i64
+  %acc_copy_dim1 = arith.constant 3 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 38 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxf32_times_DYNxDYNxf32_into_DYNxDYNxf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 6 : i64
+  %k = arith.constant 13 : i64
+  %n = arith.constant 3 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_6x13xf32_times_13x3xf32_into_6x3xf32_6_13_3_acc_13() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 6x13x3"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 6 : i64
+  %lhs_dim1 = arith.constant 13 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 39 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 13 : i64
+  %rhs_dim1 = arith.constant 3 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 40 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 6 : i64
+  %acc_dim1 = arith.constant 3 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 41 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 6 : i64
+  %acc_copy_dim1 = arith.constant 3 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 41 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_6x13xf32_times_13x3xf32_into_6x3xf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 6 : i64
+  %k = arith.constant 13 : i64
+  %n = arith.constant 3 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_DYNxDYNxf32_times_DYNxDYNxf32_into_DYNxDYNxf32_15_37_7_14() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 15x37x7"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 15 : i64
+  %lhs_dim1 = arith.constant 37 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 42 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 37 : i64
+  %rhs_dim1 = arith.constant 7 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 43 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_DYNxDYNxf32_times_DYNxDYNxf32_into_DYNxDYNxf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 15 : i64
+  %k = arith.constant 37 : i64
+  %n = arith.constant 7 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_15x37xf32_times_37x7xf32_into_15x7xf32_15_37_7_15() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 15x37x7"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 15 : i64
+  %lhs_dim1 = arith.constant 37 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 44 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 37 : i64
+  %rhs_dim1 = arith.constant 7 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 45 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_15x37xf32_times_37x7xf32_into_15x7xf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 15 : i64
+  %k = arith.constant 37 : i64
+  %n = arith.constant 7 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_DYNxDYNxf32_times_DYNxDYNxf32_into_DYNxDYNxf32_81_19_41_acc_16() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 81x19x41"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 81 : i64
+  %lhs_dim1 = arith.constant 19 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 46 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 19 : i64
+  %rhs_dim1 = arith.constant 41 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 47 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 81 : i64
+  %acc_dim1 = arith.constant 41 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 48 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 81 : i64
+  %acc_copy_dim1 = arith.constant 41 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 48 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxf32_times_DYNxDYNxf32_into_DYNxDYNxf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 81 : i64
+  %k = arith.constant 19 : i64
+  %n = arith.constant 41 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_81x19xf32_times_19x41xf32_into_81x41xf32_81_19_41_acc_17() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 81x19x41"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 81 : i64
+  %lhs_dim1 = arith.constant 19 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 49 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 19 : i64
+  %rhs_dim1 = arith.constant 41 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 50 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 81 : i64
+  %acc_dim1 = arith.constant 41 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 51 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 81 : i64
+  %acc_copy_dim1 = arith.constant 41 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 51 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_81x19xf32_times_19x41xf32_into_81x41xf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 81 : i64
+  %k = arith.constant 19 : i64
+  %n = arith.constant 41 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_DYNxDYNxf32_times_DYNxDYNxf32_into_DYNxDYNxf32_1_10_10_acc_18() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1x10x10"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1 : i64
+  %lhs_dim1 = arith.constant 10 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 52 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 10 : i64
+  %rhs_dim1 = arith.constant 10 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 53 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 1 : i64
+  %acc_dim1 = arith.constant 10 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 54 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 1 : i64
+  %acc_copy_dim1 = arith.constant 10 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 54 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxf32_times_DYNxDYNxf32_into_DYNxDYNxf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1 : i64
+  %k = arith.constant 10 : i64
+  %n = arith.constant 10 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_1x10xf32_times_10x10xf32_into_1x10xf32_1_10_10_acc_19() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1x10x10"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1 : i64
+  %lhs_dim1 = arith.constant 10 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 55 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 10 : i64
+  %rhs_dim1 = arith.constant 10 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 56 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 1 : i64
+  %acc_dim1 = arith.constant 10 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 57 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 1 : i64
+  %acc_copy_dim1 = arith.constant 10 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 57 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_1x10xf32_times_10x10xf32_into_1x10xf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1 : i64
+  %k = arith.constant 10 : i64
+  %n = arith.constant 10 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_DYNxDYNxf32_times_DYNxDYNxf32_into_DYNxDYNxf32_1_10_10_20() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1x10x10"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1 : i64
+  %lhs_dim1 = arith.constant 10 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 58 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 10 : i64
+  %rhs_dim1 = arith.constant 10 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 59 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_DYNxDYNxf32_times_DYNxDYNxf32_into_DYNxDYNxf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1 : i64
+  %k = arith.constant 10 : i64
+  %n = arith.constant 10 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_1x10xf32_times_10x10xf32_into_1x10xf32_1_10_10_21() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1x10x10"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1 : i64
+  %lhs_dim1 = arith.constant 10 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 60 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 10 : i64
+  %rhs_dim1 = arith.constant 10 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 61 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_1x10xf32_times_10x10xf32_into_1x10xf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1 : i64
+  %k = arith.constant 10 : i64
+  %n = arith.constant 10 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_DYNxDYNxf32_times_DYNxDYNxf32_into_DYNxDYNxf32_10_1_10_acc_22() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 10x1x10"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 10 : i64
+  %lhs_dim1 = arith.constant 1 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 62 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1 : i64
+  %rhs_dim1 = arith.constant 10 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 63 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 10 : i64
+  %acc_dim1 = arith.constant 10 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 64 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 10 : i64
+  %acc_copy_dim1 = arith.constant 10 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 64 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxf32_times_DYNxDYNxf32_into_DYNxDYNxf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 10 : i64
+  %k = arith.constant 1 : i64
+  %n = arith.constant 10 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_10x1xf32_times_1x10xf32_into_10x10xf32_10_1_10_acc_23() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 10x1x10"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 10 : i64
+  %lhs_dim1 = arith.constant 1 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 65 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1 : i64
+  %rhs_dim1 = arith.constant 10 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 66 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 10 : i64
+  %acc_dim1 = arith.constant 10 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 67 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 10 : i64
+  %acc_copy_dim1 = arith.constant 10 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 67 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_10x1xf32_times_1x10xf32_into_10x10xf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 10 : i64
+  %k = arith.constant 1 : i64
+  %n = arith.constant 10 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_DYNxDYNxf32_times_DYNxDYNxf32_into_DYNxDYNxf32_10_10_1_acc_24() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 10x10x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 10 : i64
+  %lhs_dim1 = arith.constant 10 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 68 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 10 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 69 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 10 : i64
+  %acc_dim1 = arith.constant 1 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 70 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 10 : i64
+  %acc_copy_dim1 = arith.constant 1 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 70 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxf32_times_DYNxDYNxf32_into_DYNxDYNxf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 10 : i64
+  %k = arith.constant 10 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_10x10xf32_times_10x1xf32_into_10x1xf32_10_10_1_acc_25() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 10x10x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 10 : i64
+  %lhs_dim1 = arith.constant 10 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 71 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 10 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 72 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 10 : i64
+  %acc_dim1 = arith.constant 1 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 73 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 10 : i64
+  %acc_copy_dim1 = arith.constant 1 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 73 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_10x10xf32_times_10x1xf32_into_10x1xf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 10 : i64
+  %k = arith.constant 10 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_DYNxDYNxf32_times_DYNxDYNxf32_into_DYNxDYNxf32_10_10_1_26() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 10x10x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 10 : i64
+  %lhs_dim1 = arith.constant 10 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 74 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 10 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 75 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_DYNxDYNxf32_times_DYNxDYNxf32_into_DYNxDYNxf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 10 : i64
+  %k = arith.constant 10 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_10x10xf32_times_10x1xf32_into_10x1xf32_10_10_1_27() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 10x10x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 10 : i64
+  %lhs_dim1 = arith.constant 10 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 76 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 10 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 77 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_10x10xf32_times_10x1xf32_into_10x1xf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 10 : i64
+  %k = arith.constant 10 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+
+}

--- a/matmul/tests/generated/matmul_f32_f32_small_matmul.mlir
+++ b/matmul/tests/generated/matmul_f32_f32_small_matmul.mlir
@@ -1,0 +1,99 @@
+func.func @matmul_accumulate_DYNxDYNxf32_times_DYNxDYNxf32_into_DYNxDYNxf32(%lhs: tensor<?x?xf32>, %rhs: tensor<?x?xf32>, %acc: tensor<?x?xf32>) -> tensor<?x?xf32> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<?x?xf32>, tensor<?x?xf32>) outs(%acc: tensor<?x?xf32>) -> tensor<?x?xf32>
+  return %result: tensor<?x?xf32>
+}
+
+func.func @matmul_accumulate_1x1xf32_times_1x1xf32_into_1x1xf32(%lhs: tensor<1x1xf32>, %rhs: tensor<1x1xf32>, %acc: tensor<1x1xf32>) -> tensor<1x1xf32> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<1x1xf32>, tensor<1x1xf32>) outs(%acc: tensor<1x1xf32>) -> tensor<1x1xf32>
+  return %result: tensor<1x1xf32>
+}
+
+func.func @matmul_DYNxDYNxf32_times_DYNxDYNxf32_into_DYNxDYNxf32(%lhs: tensor<?x?xf32>, %rhs: tensor<?x?xf32>) -> tensor<?x?xf32> {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %acc_dim0 = tensor.dim %lhs, %c0 : tensor<?x?xf32>
+  %acc_dim1 = tensor.dim %rhs, %c1 : tensor<?x?xf32>
+  %init_acc = tensor.empty(%acc_dim0, %acc_dim1) : tensor<?x?xf32>
+  %c0_acc_type = arith.constant 0.0: f32
+  %acc = linalg.fill ins(%c0_acc_type : f32) outs(%init_acc : tensor<?x?xf32>) -> tensor<?x?xf32>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<?x?xf32>, tensor<?x?xf32>) outs(%acc: tensor<?x?xf32>) -> tensor<?x?xf32>
+  return %result: tensor<?x?xf32>
+}
+
+func.func @matmul_1x1xf32_times_1x1xf32_into_1x1xf32(%lhs: tensor<1x1xf32>, %rhs: tensor<1x1xf32>) -> tensor<1x1xf32> {
+  %init_acc = tensor.empty() : tensor<1x1xf32>
+  %c0_acc_type = arith.constant 0.0: f32
+  %acc = linalg.fill ins(%c0_acc_type : f32) outs(%init_acc : tensor<1x1xf32>) -> tensor<1x1xf32>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<1x1xf32>, tensor<1x1xf32>) outs(%acc: tensor<1x1xf32>) -> tensor<1x1xf32>
+  return %result: tensor<1x1xf32>
+}
+
+func.func @matmul_accumulate_2x2xf32_times_2x2xf32_into_2x2xf32(%lhs: tensor<2x2xf32>, %rhs: tensor<2x2xf32>, %acc: tensor<2x2xf32>) -> tensor<2x2xf32> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<2x2xf32>, tensor<2x2xf32>) outs(%acc: tensor<2x2xf32>) -> tensor<2x2xf32>
+  return %result: tensor<2x2xf32>
+}
+
+func.func @matmul_accumulate_4x4xf32_times_4x4xf32_into_4x4xf32(%lhs: tensor<4x4xf32>, %rhs: tensor<4x4xf32>, %acc: tensor<4x4xf32>) -> tensor<4x4xf32> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<4x4xf32>, tensor<4x4xf32>) outs(%acc: tensor<4x4xf32>) -> tensor<4x4xf32>
+  return %result: tensor<4x4xf32>
+}
+
+func.func @matmul_accumulate_8x8xf32_times_8x8xf32_into_8x8xf32(%lhs: tensor<8x8xf32>, %rhs: tensor<8x8xf32>, %acc: tensor<8x8xf32>) -> tensor<8x8xf32> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<8x8xf32>, tensor<8x8xf32>) outs(%acc: tensor<8x8xf32>) -> tensor<8x8xf32>
+  return %result: tensor<8x8xf32>
+}
+
+func.func @matmul_accumulate_9x9xf32_times_9x9xf32_into_9x9xf32(%lhs: tensor<9x9xf32>, %rhs: tensor<9x9xf32>, %acc: tensor<9x9xf32>) -> tensor<9x9xf32> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<9x9xf32>, tensor<9x9xf32>) outs(%acc: tensor<9x9xf32>) -> tensor<9x9xf32>
+  return %result: tensor<9x9xf32>
+}
+
+func.func @matmul_accumulate_6x13xf32_times_13x3xf32_into_6x3xf32(%lhs: tensor<6x13xf32>, %rhs: tensor<13x3xf32>, %acc: tensor<6x3xf32>) -> tensor<6x3xf32> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<6x13xf32>, tensor<13x3xf32>) outs(%acc: tensor<6x3xf32>) -> tensor<6x3xf32>
+  return %result: tensor<6x3xf32>
+}
+
+func.func @matmul_15x37xf32_times_37x7xf32_into_15x7xf32(%lhs: tensor<15x37xf32>, %rhs: tensor<37x7xf32>) -> tensor<15x7xf32> {
+  %init_acc = tensor.empty() : tensor<15x7xf32>
+  %c0_acc_type = arith.constant 0.0: f32
+  %acc = linalg.fill ins(%c0_acc_type : f32) outs(%init_acc : tensor<15x7xf32>) -> tensor<15x7xf32>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<15x37xf32>, tensor<37x7xf32>) outs(%acc: tensor<15x7xf32>) -> tensor<15x7xf32>
+  return %result: tensor<15x7xf32>
+}
+
+func.func @matmul_accumulate_81x19xf32_times_19x41xf32_into_81x41xf32(%lhs: tensor<81x19xf32>, %rhs: tensor<19x41xf32>, %acc: tensor<81x41xf32>) -> tensor<81x41xf32> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<81x19xf32>, tensor<19x41xf32>) outs(%acc: tensor<81x41xf32>) -> tensor<81x41xf32>
+  return %result: tensor<81x41xf32>
+}
+
+func.func @matmul_accumulate_1x10xf32_times_10x10xf32_into_1x10xf32(%lhs: tensor<1x10xf32>, %rhs: tensor<10x10xf32>, %acc: tensor<1x10xf32>) -> tensor<1x10xf32> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<1x10xf32>, tensor<10x10xf32>) outs(%acc: tensor<1x10xf32>) -> tensor<1x10xf32>
+  return %result: tensor<1x10xf32>
+}
+
+func.func @matmul_1x10xf32_times_10x10xf32_into_1x10xf32(%lhs: tensor<1x10xf32>, %rhs: tensor<10x10xf32>) -> tensor<1x10xf32> {
+  %init_acc = tensor.empty() : tensor<1x10xf32>
+  %c0_acc_type = arith.constant 0.0: f32
+  %acc = linalg.fill ins(%c0_acc_type : f32) outs(%init_acc : tensor<1x10xf32>) -> tensor<1x10xf32>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<1x10xf32>, tensor<10x10xf32>) outs(%acc: tensor<1x10xf32>) -> tensor<1x10xf32>
+  return %result: tensor<1x10xf32>
+}
+
+func.func @matmul_accumulate_10x1xf32_times_1x10xf32_into_10x10xf32(%lhs: tensor<10x1xf32>, %rhs: tensor<1x10xf32>, %acc: tensor<10x10xf32>) -> tensor<10x10xf32> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<10x1xf32>, tensor<1x10xf32>) outs(%acc: tensor<10x10xf32>) -> tensor<10x10xf32>
+  return %result: tensor<10x10xf32>
+}
+
+func.func @matmul_accumulate_10x10xf32_times_10x1xf32_into_10x1xf32(%lhs: tensor<10x10xf32>, %rhs: tensor<10x1xf32>, %acc: tensor<10x1xf32>) -> tensor<10x1xf32> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<10x10xf32>, tensor<10x1xf32>) outs(%acc: tensor<10x1xf32>) -> tensor<10x1xf32>
+  return %result: tensor<10x1xf32>
+}
+
+func.func @matmul_10x10xf32_times_10x1xf32_into_10x1xf32(%lhs: tensor<10x10xf32>, %rhs: tensor<10x1xf32>) -> tensor<10x1xf32> {
+  %init_acc = tensor.empty() : tensor<10x1xf32>
+  %c0_acc_type = arith.constant 0.0: f32
+  %acc = linalg.fill ins(%c0_acc_type : f32) outs(%init_acc : tensor<10x1xf32>) -> tensor<10x1xf32>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<10x10xf32>, tensor<10x1xf32>) outs(%acc: tensor<10x1xf32>) -> tensor<10x1xf32>
+  return %result: tensor<10x1xf32>
+}
+

--- a/matmul/tests/generated/matmul_f8E4M3FNUZ_f32_gpu_large_aligned_calls.mlir
+++ b/matmul/tests/generated/matmul_f8E4M3FNUZ_f32_gpu_large_aligned_calls.mlir
@@ -1,0 +1,71 @@
+builtin.module @calls attributes {
+  
+} {
+
+func.func private @matmul_test.generate_random_matrix(%device: !hal.device, %dim0: i64, %dim1: i64, %element_type: i32, %seed: i32) -> !hal.buffer_view
+func.func private @matmul_test.check_matmul_results(%device: !hal.device, %m: i64, %k: i64, %n: i64, %transpose_rhs: i32, %lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view, %actual_result: !hal.buffer_view)
+
+func.func private @module.matmul_accumulate_512x128xf8E4M3FNUZ_times_128x512xf8E4M3FNUZ_into_512x512xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_512x128xf8E4M3FNUZ_times_128x512xf8E4M3FNUZ_into_512x512xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+
+func.func @matmul_accumulate_512x128xf8E4M3FNUZ_times_128x512xf8E4M3FNUZ_into_512x512xf32_512_128_512_acc_0() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 512x128x512"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 512 : i64
+  %lhs_dim1 = arith.constant 128 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 2 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 128 : i64
+  %rhs_dim1 = arith.constant 512 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 3 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 512 : i64
+  %acc_dim1 = arith.constant 512 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 4 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 512 : i64
+  %acc_copy_dim1 = arith.constant 512 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 4 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_512x128xf8E4M3FNUZ_times_128x512xf8E4M3FNUZ_into_512x512xf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 512 : i64
+  %k = arith.constant 128 : i64
+  %n = arith.constant 512 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_512x128xf8E4M3FNUZ_times_128x512xf8E4M3FNUZ_into_512x512xf32_512_128_512_1() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 512x128x512"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 512 : i64
+  %lhs_dim1 = arith.constant 128 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 5 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 128 : i64
+  %rhs_dim1 = arith.constant 512 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 6 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_512x128xf8E4M3FNUZ_times_128x512xf8E4M3FNUZ_into_512x512xf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 512 : i64
+  %k = arith.constant 128 : i64
+  %n = arith.constant 512 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+
+}

--- a/matmul/tests/generated/matmul_f8E4M3FNUZ_f32_gpu_large_aligned_matmul.mlir
+++ b/matmul/tests/generated/matmul_f8E4M3FNUZ_f32_gpu_large_aligned_matmul.mlir
@@ -1,0 +1,15 @@
+func.func @matmul_accumulate_512x128xf8E4M3FNUZ_times_128x512xf8E4M3FNUZ_into_512x512xf32(%lhs: tensor<512x128xf32>, %rhs: tensor<128x512xf32>, %acc: tensor<512x512xf32>) -> tensor<512x512xf32> {
+  %lhs_casted = arith.truncf %lhs: tensor<512x128xf32> to tensor<512x128xf8E4M3FNUZ>
+  %rhs_casted = arith.truncf %rhs: tensor<128x512xf32> to tensor<128x512xf8E4M3FNUZ>
+  %result = linalg.matmul ins(%lhs_casted, %rhs_casted: tensor<512x128xf8E4M3FNUZ>, tensor<128x512xf8E4M3FNUZ>) outs(%acc: tensor<512x512xf32>) -> tensor<512x512xf32>  return %result: tensor<512x512xf32>
+}
+
+func.func @matmul_512x128xf8E4M3FNUZ_times_128x512xf8E4M3FNUZ_into_512x512xf32(%lhs: tensor<512x128xf32>, %rhs: tensor<128x512xf32>) -> tensor<512x512xf32> {
+  %init_acc = tensor.empty() : tensor<512x512xf32>
+  %c0_acc_type = arith.constant 0.0: f32
+  %acc = linalg.fill ins(%c0_acc_type : f32) outs(%init_acc : tensor<512x512xf32>) -> tensor<512x512xf32>
+  %lhs_casted = arith.truncf %lhs: tensor<512x128xf32> to tensor<512x128xf8E4M3FNUZ>
+  %rhs_casted = arith.truncf %rhs: tensor<128x512xf32> to tensor<128x512xf8E4M3FNUZ>
+  %result = linalg.matmul ins(%lhs_casted, %rhs_casted: tensor<512x128xf8E4M3FNUZ>, tensor<128x512xf8E4M3FNUZ>) outs(%acc: tensor<512x512xf32>) -> tensor<512x512xf32>  return %result: tensor<512x512xf32>
+}
+

--- a/matmul/tests/generated/matmul_f8E4M3FNUZ_f32_gpu_large_calls.mlir
+++ b/matmul/tests/generated/matmul_f8E4M3FNUZ_f32_gpu_large_calls.mlir
@@ -1,0 +1,270 @@
+builtin.module @calls attributes {
+  
+} {
+
+func.func private @matmul_test.generate_random_matrix(%device: !hal.device, %dim0: i64, %dim1: i64, %element_type: i32, %seed: i32) -> !hal.buffer_view
+func.func private @matmul_test.check_matmul_results(%device: !hal.device, %m: i64, %k: i64, %n: i64, %transpose_rhs: i32, %lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view, %actual_result: !hal.buffer_view)
+
+func.func private @module.matmul_457x330xf8E4M3FNUZ_times_330x512xf8E4M3FNUZ_into_457x512xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_457x330xf8E4M3FNUZ_times_330x514xf8E4M3FNUZ_into_457x514xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_438x330xf8E4M3FNUZ_times_330x514xf8E4M3FNUZ_into_438x514xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_540x332xf8E4M3FNUZ_times_332x516xf8E4M3FNUZ_into_540x516xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_1000x4xf8E4M3FNUZ_times_4x512xf8E4M3FNUZ_into_1000x512xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_4x1000xf8E4M3FNUZ_times_1000x512xf8E4M3FNUZ_into_4x512xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_512x1000xf8E4M3FNUZ_times_1000x4xf8E4M3FNUZ_into_512x4xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_512x128xf8E4M3FNUZ_times_128x500xf8E4M3FNUZ_into_512x500xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_457x160xf8E4M3FNUZ_times_160x512xf8E4M3FNUZ_into_457x512xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_512x330xf8E4M3FNUZ_times_330x512xf8E4M3FNUZ_into_512x512xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+
+func.func @matmul_457x330xf8E4M3FNUZ_times_330x512xf8E4M3FNUZ_into_457x512xf32_457_330_512_0() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 457x330x512"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 457 : i64
+  %lhs_dim1 = arith.constant 330 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 2 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 330 : i64
+  %rhs_dim1 = arith.constant 512 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 3 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_457x330xf8E4M3FNUZ_times_330x512xf8E4M3FNUZ_into_457x512xf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 457 : i64
+  %k = arith.constant 330 : i64
+  %n = arith.constant 512 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_457x330xf8E4M3FNUZ_times_330x514xf8E4M3FNUZ_into_457x514xf32_457_330_514_1() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 457x330x514"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 457 : i64
+  %lhs_dim1 = arith.constant 330 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 4 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 330 : i64
+  %rhs_dim1 = arith.constant 514 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 5 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_457x330xf8E4M3FNUZ_times_330x514xf8E4M3FNUZ_into_457x514xf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 457 : i64
+  %k = arith.constant 330 : i64
+  %n = arith.constant 514 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_438x330xf8E4M3FNUZ_times_330x514xf8E4M3FNUZ_into_438x514xf32_438_330_514_2() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 438x330x514"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 438 : i64
+  %lhs_dim1 = arith.constant 330 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 6 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 330 : i64
+  %rhs_dim1 = arith.constant 514 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 7 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_438x330xf8E4M3FNUZ_times_330x514xf8E4M3FNUZ_into_438x514xf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 438 : i64
+  %k = arith.constant 330 : i64
+  %n = arith.constant 514 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_540x332xf8E4M3FNUZ_times_332x516xf8E4M3FNUZ_into_540x516xf32_540_332_516_3() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 540x332x516"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 540 : i64
+  %lhs_dim1 = arith.constant 332 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 8 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 332 : i64
+  %rhs_dim1 = arith.constant 516 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 9 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_540x332xf8E4M3FNUZ_times_332x516xf8E4M3FNUZ_into_540x516xf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 540 : i64
+  %k = arith.constant 332 : i64
+  %n = arith.constant 516 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_1000x4xf8E4M3FNUZ_times_4x512xf8E4M3FNUZ_into_1000x512xf32_1000_4_512_4() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1000x4x512"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1000 : i64
+  %lhs_dim1 = arith.constant 4 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 10 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 4 : i64
+  %rhs_dim1 = arith.constant 512 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 11 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_1000x4xf8E4M3FNUZ_times_4x512xf8E4M3FNUZ_into_1000x512xf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1000 : i64
+  %k = arith.constant 4 : i64
+  %n = arith.constant 512 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_4x1000xf8E4M3FNUZ_times_1000x512xf8E4M3FNUZ_into_4x512xf32_4_1000_512_5() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 4x1000x512"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 4 : i64
+  %lhs_dim1 = arith.constant 1000 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 12 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1000 : i64
+  %rhs_dim1 = arith.constant 512 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 13 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_4x1000xf8E4M3FNUZ_times_1000x512xf8E4M3FNUZ_into_4x512xf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 4 : i64
+  %k = arith.constant 1000 : i64
+  %n = arith.constant 512 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_512x1000xf8E4M3FNUZ_times_1000x4xf8E4M3FNUZ_into_512x4xf32_512_1000_4_6() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 512x1000x4"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 512 : i64
+  %lhs_dim1 = arith.constant 1000 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 14 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1000 : i64
+  %rhs_dim1 = arith.constant 4 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 15 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_512x1000xf8E4M3FNUZ_times_1000x4xf8E4M3FNUZ_into_512x4xf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 512 : i64
+  %k = arith.constant 1000 : i64
+  %n = arith.constant 4 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_512x128xf8E4M3FNUZ_times_128x500xf8E4M3FNUZ_into_512x500xf32_512_128_500_7() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 512x128x500"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 512 : i64
+  %lhs_dim1 = arith.constant 128 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 16 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 128 : i64
+  %rhs_dim1 = arith.constant 500 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 17 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_512x128xf8E4M3FNUZ_times_128x500xf8E4M3FNUZ_into_512x500xf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 512 : i64
+  %k = arith.constant 128 : i64
+  %n = arith.constant 500 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_457x160xf8E4M3FNUZ_times_160x512xf8E4M3FNUZ_into_457x512xf32_457_160_512_8() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 457x160x512"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 457 : i64
+  %lhs_dim1 = arith.constant 160 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 18 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 160 : i64
+  %rhs_dim1 = arith.constant 512 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 19 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_457x160xf8E4M3FNUZ_times_160x512xf8E4M3FNUZ_into_457x512xf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 457 : i64
+  %k = arith.constant 160 : i64
+  %n = arith.constant 512 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_512x330xf8E4M3FNUZ_times_330x512xf8E4M3FNUZ_into_512x512xf32_512_330_512_9() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 512x330x512"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 512 : i64
+  %lhs_dim1 = arith.constant 330 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 20 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 330 : i64
+  %rhs_dim1 = arith.constant 512 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 21 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_512x330xf8E4M3FNUZ_times_330x512xf8E4M3FNUZ_into_512x512xf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 512 : i64
+  %k = arith.constant 330 : i64
+  %n = arith.constant 512 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+
+}

--- a/matmul/tests/generated/matmul_f8E4M3FNUZ_f32_gpu_large_matmul.mlir
+++ b/matmul/tests/generated/matmul_f8E4M3FNUZ_f32_gpu_large_matmul.mlir
@@ -1,0 +1,90 @@
+func.func @matmul_457x330xf8E4M3FNUZ_times_330x512xf8E4M3FNUZ_into_457x512xf32(%lhs: tensor<457x330xf32>, %rhs: tensor<330x512xf32>) -> tensor<457x512xf32> {
+  %init_acc = tensor.empty() : tensor<457x512xf32>
+  %c0_acc_type = arith.constant 0.0: f32
+  %acc = linalg.fill ins(%c0_acc_type : f32) outs(%init_acc : tensor<457x512xf32>) -> tensor<457x512xf32>
+  %lhs_casted = arith.truncf %lhs: tensor<457x330xf32> to tensor<457x330xf8E4M3FNUZ>
+  %rhs_casted = arith.truncf %rhs: tensor<330x512xf32> to tensor<330x512xf8E4M3FNUZ>
+  %result = linalg.matmul ins(%lhs_casted, %rhs_casted: tensor<457x330xf8E4M3FNUZ>, tensor<330x512xf8E4M3FNUZ>) outs(%acc: tensor<457x512xf32>) -> tensor<457x512xf32>  return %result: tensor<457x512xf32>
+}
+
+func.func @matmul_457x330xf8E4M3FNUZ_times_330x514xf8E4M3FNUZ_into_457x514xf32(%lhs: tensor<457x330xf32>, %rhs: tensor<330x514xf32>) -> tensor<457x514xf32> {
+  %init_acc = tensor.empty() : tensor<457x514xf32>
+  %c0_acc_type = arith.constant 0.0: f32
+  %acc = linalg.fill ins(%c0_acc_type : f32) outs(%init_acc : tensor<457x514xf32>) -> tensor<457x514xf32>
+  %lhs_casted = arith.truncf %lhs: tensor<457x330xf32> to tensor<457x330xf8E4M3FNUZ>
+  %rhs_casted = arith.truncf %rhs: tensor<330x514xf32> to tensor<330x514xf8E4M3FNUZ>
+  %result = linalg.matmul ins(%lhs_casted, %rhs_casted: tensor<457x330xf8E4M3FNUZ>, tensor<330x514xf8E4M3FNUZ>) outs(%acc: tensor<457x514xf32>) -> tensor<457x514xf32>  return %result: tensor<457x514xf32>
+}
+
+func.func @matmul_438x330xf8E4M3FNUZ_times_330x514xf8E4M3FNUZ_into_438x514xf32(%lhs: tensor<438x330xf32>, %rhs: tensor<330x514xf32>) -> tensor<438x514xf32> {
+  %init_acc = tensor.empty() : tensor<438x514xf32>
+  %c0_acc_type = arith.constant 0.0: f32
+  %acc = linalg.fill ins(%c0_acc_type : f32) outs(%init_acc : tensor<438x514xf32>) -> tensor<438x514xf32>
+  %lhs_casted = arith.truncf %lhs: tensor<438x330xf32> to tensor<438x330xf8E4M3FNUZ>
+  %rhs_casted = arith.truncf %rhs: tensor<330x514xf32> to tensor<330x514xf8E4M3FNUZ>
+  %result = linalg.matmul ins(%lhs_casted, %rhs_casted: tensor<438x330xf8E4M3FNUZ>, tensor<330x514xf8E4M3FNUZ>) outs(%acc: tensor<438x514xf32>) -> tensor<438x514xf32>  return %result: tensor<438x514xf32>
+}
+
+func.func @matmul_540x332xf8E4M3FNUZ_times_332x516xf8E4M3FNUZ_into_540x516xf32(%lhs: tensor<540x332xf32>, %rhs: tensor<332x516xf32>) -> tensor<540x516xf32> {
+  %init_acc = tensor.empty() : tensor<540x516xf32>
+  %c0_acc_type = arith.constant 0.0: f32
+  %acc = linalg.fill ins(%c0_acc_type : f32) outs(%init_acc : tensor<540x516xf32>) -> tensor<540x516xf32>
+  %lhs_casted = arith.truncf %lhs: tensor<540x332xf32> to tensor<540x332xf8E4M3FNUZ>
+  %rhs_casted = arith.truncf %rhs: tensor<332x516xf32> to tensor<332x516xf8E4M3FNUZ>
+  %result = linalg.matmul ins(%lhs_casted, %rhs_casted: tensor<540x332xf8E4M3FNUZ>, tensor<332x516xf8E4M3FNUZ>) outs(%acc: tensor<540x516xf32>) -> tensor<540x516xf32>  return %result: tensor<540x516xf32>
+}
+
+func.func @matmul_1000x4xf8E4M3FNUZ_times_4x512xf8E4M3FNUZ_into_1000x512xf32(%lhs: tensor<1000x4xf32>, %rhs: tensor<4x512xf32>) -> tensor<1000x512xf32> {
+  %init_acc = tensor.empty() : tensor<1000x512xf32>
+  %c0_acc_type = arith.constant 0.0: f32
+  %acc = linalg.fill ins(%c0_acc_type : f32) outs(%init_acc : tensor<1000x512xf32>) -> tensor<1000x512xf32>
+  %lhs_casted = arith.truncf %lhs: tensor<1000x4xf32> to tensor<1000x4xf8E4M3FNUZ>
+  %rhs_casted = arith.truncf %rhs: tensor<4x512xf32> to tensor<4x512xf8E4M3FNUZ>
+  %result = linalg.matmul ins(%lhs_casted, %rhs_casted: tensor<1000x4xf8E4M3FNUZ>, tensor<4x512xf8E4M3FNUZ>) outs(%acc: tensor<1000x512xf32>) -> tensor<1000x512xf32>  return %result: tensor<1000x512xf32>
+}
+
+func.func @matmul_4x1000xf8E4M3FNUZ_times_1000x512xf8E4M3FNUZ_into_4x512xf32(%lhs: tensor<4x1000xf32>, %rhs: tensor<1000x512xf32>) -> tensor<4x512xf32> {
+  %init_acc = tensor.empty() : tensor<4x512xf32>
+  %c0_acc_type = arith.constant 0.0: f32
+  %acc = linalg.fill ins(%c0_acc_type : f32) outs(%init_acc : tensor<4x512xf32>) -> tensor<4x512xf32>
+  %lhs_casted = arith.truncf %lhs: tensor<4x1000xf32> to tensor<4x1000xf8E4M3FNUZ>
+  %rhs_casted = arith.truncf %rhs: tensor<1000x512xf32> to tensor<1000x512xf8E4M3FNUZ>
+  %result = linalg.matmul ins(%lhs_casted, %rhs_casted: tensor<4x1000xf8E4M3FNUZ>, tensor<1000x512xf8E4M3FNUZ>) outs(%acc: tensor<4x512xf32>) -> tensor<4x512xf32>  return %result: tensor<4x512xf32>
+}
+
+func.func @matmul_512x1000xf8E4M3FNUZ_times_1000x4xf8E4M3FNUZ_into_512x4xf32(%lhs: tensor<512x1000xf32>, %rhs: tensor<1000x4xf32>) -> tensor<512x4xf32> {
+  %init_acc = tensor.empty() : tensor<512x4xf32>
+  %c0_acc_type = arith.constant 0.0: f32
+  %acc = linalg.fill ins(%c0_acc_type : f32) outs(%init_acc : tensor<512x4xf32>) -> tensor<512x4xf32>
+  %lhs_casted = arith.truncf %lhs: tensor<512x1000xf32> to tensor<512x1000xf8E4M3FNUZ>
+  %rhs_casted = arith.truncf %rhs: tensor<1000x4xf32> to tensor<1000x4xf8E4M3FNUZ>
+  %result = linalg.matmul ins(%lhs_casted, %rhs_casted: tensor<512x1000xf8E4M3FNUZ>, tensor<1000x4xf8E4M3FNUZ>) outs(%acc: tensor<512x4xf32>) -> tensor<512x4xf32>  return %result: tensor<512x4xf32>
+}
+
+func.func @matmul_512x128xf8E4M3FNUZ_times_128x500xf8E4M3FNUZ_into_512x500xf32(%lhs: tensor<512x128xf32>, %rhs: tensor<128x500xf32>) -> tensor<512x500xf32> {
+  %init_acc = tensor.empty() : tensor<512x500xf32>
+  %c0_acc_type = arith.constant 0.0: f32
+  %acc = linalg.fill ins(%c0_acc_type : f32) outs(%init_acc : tensor<512x500xf32>) -> tensor<512x500xf32>
+  %lhs_casted = arith.truncf %lhs: tensor<512x128xf32> to tensor<512x128xf8E4M3FNUZ>
+  %rhs_casted = arith.truncf %rhs: tensor<128x500xf32> to tensor<128x500xf8E4M3FNUZ>
+  %result = linalg.matmul ins(%lhs_casted, %rhs_casted: tensor<512x128xf8E4M3FNUZ>, tensor<128x500xf8E4M3FNUZ>) outs(%acc: tensor<512x500xf32>) -> tensor<512x500xf32>  return %result: tensor<512x500xf32>
+}
+
+func.func @matmul_457x160xf8E4M3FNUZ_times_160x512xf8E4M3FNUZ_into_457x512xf32(%lhs: tensor<457x160xf32>, %rhs: tensor<160x512xf32>) -> tensor<457x512xf32> {
+  %init_acc = tensor.empty() : tensor<457x512xf32>
+  %c0_acc_type = arith.constant 0.0: f32
+  %acc = linalg.fill ins(%c0_acc_type : f32) outs(%init_acc : tensor<457x512xf32>) -> tensor<457x512xf32>
+  %lhs_casted = arith.truncf %lhs: tensor<457x160xf32> to tensor<457x160xf8E4M3FNUZ>
+  %rhs_casted = arith.truncf %rhs: tensor<160x512xf32> to tensor<160x512xf8E4M3FNUZ>
+  %result = linalg.matmul ins(%lhs_casted, %rhs_casted: tensor<457x160xf8E4M3FNUZ>, tensor<160x512xf8E4M3FNUZ>) outs(%acc: tensor<457x512xf32>) -> tensor<457x512xf32>  return %result: tensor<457x512xf32>
+}
+
+func.func @matmul_512x330xf8E4M3FNUZ_times_330x512xf8E4M3FNUZ_into_512x512xf32(%lhs: tensor<512x330xf32>, %rhs: tensor<330x512xf32>) -> tensor<512x512xf32> {
+  %init_acc = tensor.empty() : tensor<512x512xf32>
+  %c0_acc_type = arith.constant 0.0: f32
+  %acc = linalg.fill ins(%c0_acc_type : f32) outs(%init_acc : tensor<512x512xf32>) -> tensor<512x512xf32>
+  %lhs_casted = arith.truncf %lhs: tensor<512x330xf32> to tensor<512x330xf8E4M3FNUZ>
+  %rhs_casted = arith.truncf %rhs: tensor<330x512xf32> to tensor<330x512xf8E4M3FNUZ>
+  %result = linalg.matmul ins(%lhs_casted, %rhs_casted: tensor<512x330xf8E4M3FNUZ>, tensor<330x512xf8E4M3FNUZ>) outs(%acc: tensor<512x512xf32>) -> tensor<512x512xf32>  return %result: tensor<512x512xf32>
+}
+

--- a/matmul/tests/generated/matmul_f8E4M3FNUZ_f32_large_calls.mlir
+++ b/matmul/tests/generated/matmul_f8E4M3FNUZ_f32_large_calls.mlir
@@ -1,0 +1,321 @@
+builtin.module @calls attributes {
+  
+} {
+
+func.func private @matmul_test.generate_random_matrix(%device: !hal.device, %dim0: i64, %dim1: i64, %element_type: i32, %seed: i32) -> !hal.buffer_view
+func.func private @matmul_test.check_matmul_results(%device: !hal.device, %m: i64, %k: i64, %n: i64, %transpose_rhs: i32, %lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view, %actual_result: !hal.buffer_view)
+
+func.func private @module.matmul_accumulate_DYNxDYNxf8E4M3FNUZ_times_DYNxDYNxf8E4M3FNUZ_into_DYNxDYNxf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_123x456xf8E4M3FNUZ_times_456x789xf8E4M3FNUZ_into_123x789xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_DYNxDYNxf8E4M3FNUZ_times_DYNxDYNxf8E4M3FNUZ_into_DYNxDYNxf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_654x321xf8E4M3FNUZ_times_321x234xf8E4M3FNUZ_into_654x234xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_1x1000xf8E4M3FNUZ_times_1000x1000xf8E4M3FNUZ_into_1x1000xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_1000x1000xf8E4M3FNUZ_times_1000x1xf8E4M3FNUZ_into_1000x1xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_1000x1000xf8E4M3FNUZ_times_1000x1xf8E4M3FNUZ_into_1000x1xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+
+func.func @matmul_accumulate_DYNxDYNxf8E4M3FNUZ_times_DYNxDYNxf8E4M3FNUZ_into_DYNxDYNxf32_123_456_789_acc_0() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 123x456x789"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 123 : i64
+  %lhs_dim1 = arith.constant 456 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 2 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 456 : i64
+  %rhs_dim1 = arith.constant 789 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 3 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 123 : i64
+  %acc_dim1 = arith.constant 789 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 4 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 123 : i64
+  %acc_copy_dim1 = arith.constant 789 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 4 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxf8E4M3FNUZ_times_DYNxDYNxf8E4M3FNUZ_into_DYNxDYNxf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 123 : i64
+  %k = arith.constant 456 : i64
+  %n = arith.constant 789 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_123x456xf8E4M3FNUZ_times_456x789xf8E4M3FNUZ_into_123x789xf32_123_456_789_acc_1() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 123x456x789"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 123 : i64
+  %lhs_dim1 = arith.constant 456 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 5 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 456 : i64
+  %rhs_dim1 = arith.constant 789 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 6 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 123 : i64
+  %acc_dim1 = arith.constant 789 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 7 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 123 : i64
+  %acc_copy_dim1 = arith.constant 789 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 7 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_123x456xf8E4M3FNUZ_times_456x789xf8E4M3FNUZ_into_123x789xf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 123 : i64
+  %k = arith.constant 456 : i64
+  %n = arith.constant 789 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_DYNxDYNxf8E4M3FNUZ_times_DYNxDYNxf8E4M3FNUZ_into_DYNxDYNxf32_654_321_234_2() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 654x321x234"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 654 : i64
+  %lhs_dim1 = arith.constant 321 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 8 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 321 : i64
+  %rhs_dim1 = arith.constant 234 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 9 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_DYNxDYNxf8E4M3FNUZ_times_DYNxDYNxf8E4M3FNUZ_into_DYNxDYNxf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 654 : i64
+  %k = arith.constant 321 : i64
+  %n = arith.constant 234 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_654x321xf8E4M3FNUZ_times_321x234xf8E4M3FNUZ_into_654x234xf32_654_321_234_3() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 654x321x234"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 654 : i64
+  %lhs_dim1 = arith.constant 321 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 10 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 321 : i64
+  %rhs_dim1 = arith.constant 234 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 11 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_654x321xf8E4M3FNUZ_times_321x234xf8E4M3FNUZ_into_654x234xf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 654 : i64
+  %k = arith.constant 321 : i64
+  %n = arith.constant 234 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_DYNxDYNxf8E4M3FNUZ_times_DYNxDYNxf8E4M3FNUZ_into_DYNxDYNxf32_1_1000_1000_acc_4() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1x1000x1000"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1 : i64
+  %lhs_dim1 = arith.constant 1000 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 12 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1000 : i64
+  %rhs_dim1 = arith.constant 1000 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 13 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 1 : i64
+  %acc_dim1 = arith.constant 1000 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 14 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 1 : i64
+  %acc_copy_dim1 = arith.constant 1000 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 14 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxf8E4M3FNUZ_times_DYNxDYNxf8E4M3FNUZ_into_DYNxDYNxf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1 : i64
+  %k = arith.constant 1000 : i64
+  %n = arith.constant 1000 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_1x1000xf8E4M3FNUZ_times_1000x1000xf8E4M3FNUZ_into_1x1000xf32_1_1000_1000_acc_5() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1x1000x1000"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1 : i64
+  %lhs_dim1 = arith.constant 1000 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 15 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1000 : i64
+  %rhs_dim1 = arith.constant 1000 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 16 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 1 : i64
+  %acc_dim1 = arith.constant 1000 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 17 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 1 : i64
+  %acc_copy_dim1 = arith.constant 1000 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 17 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_1x1000xf8E4M3FNUZ_times_1000x1000xf8E4M3FNUZ_into_1x1000xf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1 : i64
+  %k = arith.constant 1000 : i64
+  %n = arith.constant 1000 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_DYNxDYNxf8E4M3FNUZ_times_DYNxDYNxf8E4M3FNUZ_into_DYNxDYNxf32_1000_1000_1_acc_6() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1000x1000x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1000 : i64
+  %lhs_dim1 = arith.constant 1000 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 18 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1000 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 19 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 1000 : i64
+  %acc_dim1 = arith.constant 1 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 20 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 1000 : i64
+  %acc_copy_dim1 = arith.constant 1 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 20 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxf8E4M3FNUZ_times_DYNxDYNxf8E4M3FNUZ_into_DYNxDYNxf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1000 : i64
+  %k = arith.constant 1000 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_1000x1000xf8E4M3FNUZ_times_1000x1xf8E4M3FNUZ_into_1000x1xf32_1000_1000_1_acc_7() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1000x1000x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1000 : i64
+  %lhs_dim1 = arith.constant 1000 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 21 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1000 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 22 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 1000 : i64
+  %acc_dim1 = arith.constant 1 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 23 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 1000 : i64
+  %acc_copy_dim1 = arith.constant 1 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 23 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_1000x1000xf8E4M3FNUZ_times_1000x1xf8E4M3FNUZ_into_1000x1xf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1000 : i64
+  %k = arith.constant 1000 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_DYNxDYNxf8E4M3FNUZ_times_DYNxDYNxf8E4M3FNUZ_into_DYNxDYNxf32_1000_1000_1_8() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1000x1000x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1000 : i64
+  %lhs_dim1 = arith.constant 1000 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 24 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1000 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 25 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_DYNxDYNxf8E4M3FNUZ_times_DYNxDYNxf8E4M3FNUZ_into_DYNxDYNxf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1000 : i64
+  %k = arith.constant 1000 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_1000x1000xf8E4M3FNUZ_times_1000x1xf8E4M3FNUZ_into_1000x1xf32_1000_1000_1_9() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1000x1000x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1000 : i64
+  %lhs_dim1 = arith.constant 1000 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 26 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1000 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 27 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_1000x1000xf8E4M3FNUZ_times_1000x1xf8E4M3FNUZ_into_1000x1xf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1000 : i64
+  %k = arith.constant 1000 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+
+}

--- a/matmul/tests/generated/matmul_f8E4M3FNUZ_f32_large_matmul.mlir
+++ b/matmul/tests/generated/matmul_f8E4M3FNUZ_f32_large_matmul.mlir
@@ -1,0 +1,55 @@
+func.func @matmul_accumulate_DYNxDYNxf8E4M3FNUZ_times_DYNxDYNxf8E4M3FNUZ_into_DYNxDYNxf32(%lhs: tensor<?x?xf32>, %rhs: tensor<?x?xf32>, %acc: tensor<?x?xf32>) -> tensor<?x?xf32> {
+  %lhs_casted = arith.truncf %lhs: tensor<?x?xf32> to tensor<?x?xf8E4M3FNUZ>
+  %rhs_casted = arith.truncf %rhs: tensor<?x?xf32> to tensor<?x?xf8E4M3FNUZ>
+  %result = linalg.matmul ins(%lhs_casted, %rhs_casted: tensor<?x?xf8E4M3FNUZ>, tensor<?x?xf8E4M3FNUZ>) outs(%acc: tensor<?x?xf32>) -> tensor<?x?xf32>  return %result: tensor<?x?xf32>
+}
+
+func.func @matmul_accumulate_123x456xf8E4M3FNUZ_times_456x789xf8E4M3FNUZ_into_123x789xf32(%lhs: tensor<123x456xf32>, %rhs: tensor<456x789xf32>, %acc: tensor<123x789xf32>) -> tensor<123x789xf32> {
+  %lhs_casted = arith.truncf %lhs: tensor<123x456xf32> to tensor<123x456xf8E4M3FNUZ>
+  %rhs_casted = arith.truncf %rhs: tensor<456x789xf32> to tensor<456x789xf8E4M3FNUZ>
+  %result = linalg.matmul ins(%lhs_casted, %rhs_casted: tensor<123x456xf8E4M3FNUZ>, tensor<456x789xf8E4M3FNUZ>) outs(%acc: tensor<123x789xf32>) -> tensor<123x789xf32>  return %result: tensor<123x789xf32>
+}
+
+func.func @matmul_DYNxDYNxf8E4M3FNUZ_times_DYNxDYNxf8E4M3FNUZ_into_DYNxDYNxf32(%lhs: tensor<?x?xf32>, %rhs: tensor<?x?xf32>) -> tensor<?x?xf32> {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %acc_dim0 = tensor.dim %lhs, %c0 : tensor<?x?xf32>
+  %acc_dim1 = tensor.dim %rhs, %c1 : tensor<?x?xf32>
+  %init_acc = tensor.empty(%acc_dim0, %acc_dim1) : tensor<?x?xf32>
+  %c0_acc_type = arith.constant 0.0: f32
+  %acc = linalg.fill ins(%c0_acc_type : f32) outs(%init_acc : tensor<?x?xf32>) -> tensor<?x?xf32>
+  %lhs_casted = arith.truncf %lhs: tensor<?x?xf32> to tensor<?x?xf8E4M3FNUZ>
+  %rhs_casted = arith.truncf %rhs: tensor<?x?xf32> to tensor<?x?xf8E4M3FNUZ>
+  %result = linalg.matmul ins(%lhs_casted, %rhs_casted: tensor<?x?xf8E4M3FNUZ>, tensor<?x?xf8E4M3FNUZ>) outs(%acc: tensor<?x?xf32>) -> tensor<?x?xf32>  return %result: tensor<?x?xf32>
+}
+
+func.func @matmul_654x321xf8E4M3FNUZ_times_321x234xf8E4M3FNUZ_into_654x234xf32(%lhs: tensor<654x321xf32>, %rhs: tensor<321x234xf32>) -> tensor<654x234xf32> {
+  %init_acc = tensor.empty() : tensor<654x234xf32>
+  %c0_acc_type = arith.constant 0.0: f32
+  %acc = linalg.fill ins(%c0_acc_type : f32) outs(%init_acc : tensor<654x234xf32>) -> tensor<654x234xf32>
+  %lhs_casted = arith.truncf %lhs: tensor<654x321xf32> to tensor<654x321xf8E4M3FNUZ>
+  %rhs_casted = arith.truncf %rhs: tensor<321x234xf32> to tensor<321x234xf8E4M3FNUZ>
+  %result = linalg.matmul ins(%lhs_casted, %rhs_casted: tensor<654x321xf8E4M3FNUZ>, tensor<321x234xf8E4M3FNUZ>) outs(%acc: tensor<654x234xf32>) -> tensor<654x234xf32>  return %result: tensor<654x234xf32>
+}
+
+func.func @matmul_accumulate_1x1000xf8E4M3FNUZ_times_1000x1000xf8E4M3FNUZ_into_1x1000xf32(%lhs: tensor<1x1000xf32>, %rhs: tensor<1000x1000xf32>, %acc: tensor<1x1000xf32>) -> tensor<1x1000xf32> {
+  %lhs_casted = arith.truncf %lhs: tensor<1x1000xf32> to tensor<1x1000xf8E4M3FNUZ>
+  %rhs_casted = arith.truncf %rhs: tensor<1000x1000xf32> to tensor<1000x1000xf8E4M3FNUZ>
+  %result = linalg.matmul ins(%lhs_casted, %rhs_casted: tensor<1x1000xf8E4M3FNUZ>, tensor<1000x1000xf8E4M3FNUZ>) outs(%acc: tensor<1x1000xf32>) -> tensor<1x1000xf32>  return %result: tensor<1x1000xf32>
+}
+
+func.func @matmul_accumulate_1000x1000xf8E4M3FNUZ_times_1000x1xf8E4M3FNUZ_into_1000x1xf32(%lhs: tensor<1000x1000xf32>, %rhs: tensor<1000x1xf32>, %acc: tensor<1000x1xf32>) -> tensor<1000x1xf32> {
+  %lhs_casted = arith.truncf %lhs: tensor<1000x1000xf32> to tensor<1000x1000xf8E4M3FNUZ>
+  %rhs_casted = arith.truncf %rhs: tensor<1000x1xf32> to tensor<1000x1xf8E4M3FNUZ>
+  %result = linalg.matmul ins(%lhs_casted, %rhs_casted: tensor<1000x1000xf8E4M3FNUZ>, tensor<1000x1xf8E4M3FNUZ>) outs(%acc: tensor<1000x1xf32>) -> tensor<1000x1xf32>  return %result: tensor<1000x1xf32>
+}
+
+func.func @matmul_1000x1000xf8E4M3FNUZ_times_1000x1xf8E4M3FNUZ_into_1000x1xf32(%lhs: tensor<1000x1000xf32>, %rhs: tensor<1000x1xf32>) -> tensor<1000x1xf32> {
+  %init_acc = tensor.empty() : tensor<1000x1xf32>
+  %c0_acc_type = arith.constant 0.0: f32
+  %acc = linalg.fill ins(%c0_acc_type : f32) outs(%init_acc : tensor<1000x1xf32>) -> tensor<1000x1xf32>
+  %lhs_casted = arith.truncf %lhs: tensor<1000x1000xf32> to tensor<1000x1000xf8E4M3FNUZ>
+  %rhs_casted = arith.truncf %rhs: tensor<1000x1xf32> to tensor<1000x1xf8E4M3FNUZ>
+  %result = linalg.matmul ins(%lhs_casted, %rhs_casted: tensor<1000x1000xf8E4M3FNUZ>, tensor<1000x1xf8E4M3FNUZ>) outs(%acc: tensor<1000x1xf32>) -> tensor<1000x1xf32>  return %result: tensor<1000x1xf32>
+}
+

--- a/matmul/tests/generated/matmul_f8E4M3FNUZ_f32_small_calls.mlir
+++ b/matmul/tests/generated/matmul_f8E4M3FNUZ_f32_small_calls.mlir
@@ -1,0 +1,906 @@
+builtin.module @calls attributes {
+  
+} {
+
+func.func private @matmul_test.generate_random_matrix(%device: !hal.device, %dim0: i64, %dim1: i64, %element_type: i32, %seed: i32) -> !hal.buffer_view
+func.func private @matmul_test.check_matmul_results(%device: !hal.device, %m: i64, %k: i64, %n: i64, %transpose_rhs: i32, %lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view, %actual_result: !hal.buffer_view)
+
+func.func private @module.matmul_accumulate_DYNxDYNxf8E4M3FNUZ_times_DYNxDYNxf8E4M3FNUZ_into_DYNxDYNxf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_1x1xf8E4M3FNUZ_times_1x1xf8E4M3FNUZ_into_1x1xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_DYNxDYNxf8E4M3FNUZ_times_DYNxDYNxf8E4M3FNUZ_into_DYNxDYNxf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_1x1xf8E4M3FNUZ_times_1x1xf8E4M3FNUZ_into_1x1xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_2x2xf8E4M3FNUZ_times_2x2xf8E4M3FNUZ_into_2x2xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_4x4xf8E4M3FNUZ_times_4x4xf8E4M3FNUZ_into_4x4xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_8x8xf8E4M3FNUZ_times_8x8xf8E4M3FNUZ_into_8x8xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_9x9xf8E4M3FNUZ_times_9x9xf8E4M3FNUZ_into_9x9xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_6x13xf8E4M3FNUZ_times_13x3xf8E4M3FNUZ_into_6x3xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_15x37xf8E4M3FNUZ_times_37x7xf8E4M3FNUZ_into_15x7xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_81x19xf8E4M3FNUZ_times_19x41xf8E4M3FNUZ_into_81x41xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_1x10xf8E4M3FNUZ_times_10x10xf8E4M3FNUZ_into_1x10xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_1x10xf8E4M3FNUZ_times_10x10xf8E4M3FNUZ_into_1x10xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_10x1xf8E4M3FNUZ_times_1x10xf8E4M3FNUZ_into_10x10xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_10x10xf8E4M3FNUZ_times_10x1xf8E4M3FNUZ_into_10x1xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_10x10xf8E4M3FNUZ_times_10x1xf8E4M3FNUZ_into_10x1xf32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+
+func.func @matmul_accumulate_DYNxDYNxf8E4M3FNUZ_times_DYNxDYNxf8E4M3FNUZ_into_DYNxDYNxf32_1_1_1_acc_0() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1x1x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1 : i64
+  %lhs_dim1 = arith.constant 1 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 2 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 3 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 1 : i64
+  %acc_dim1 = arith.constant 1 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 4 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 1 : i64
+  %acc_copy_dim1 = arith.constant 1 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 4 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxf8E4M3FNUZ_times_DYNxDYNxf8E4M3FNUZ_into_DYNxDYNxf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1 : i64
+  %k = arith.constant 1 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_1x1xf8E4M3FNUZ_times_1x1xf8E4M3FNUZ_into_1x1xf32_1_1_1_acc_1() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1x1x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1 : i64
+  %lhs_dim1 = arith.constant 1 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 5 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 6 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 1 : i64
+  %acc_dim1 = arith.constant 1 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 7 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 1 : i64
+  %acc_copy_dim1 = arith.constant 1 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 7 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_1x1xf8E4M3FNUZ_times_1x1xf8E4M3FNUZ_into_1x1xf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1 : i64
+  %k = arith.constant 1 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_DYNxDYNxf8E4M3FNUZ_times_DYNxDYNxf8E4M3FNUZ_into_DYNxDYNxf32_1_1_1_2() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1x1x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1 : i64
+  %lhs_dim1 = arith.constant 1 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 8 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 9 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_DYNxDYNxf8E4M3FNUZ_times_DYNxDYNxf8E4M3FNUZ_into_DYNxDYNxf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1 : i64
+  %k = arith.constant 1 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_1x1xf8E4M3FNUZ_times_1x1xf8E4M3FNUZ_into_1x1xf32_1_1_1_3() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1x1x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1 : i64
+  %lhs_dim1 = arith.constant 1 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 10 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 11 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_1x1xf8E4M3FNUZ_times_1x1xf8E4M3FNUZ_into_1x1xf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1 : i64
+  %k = arith.constant 1 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_DYNxDYNxf8E4M3FNUZ_times_DYNxDYNxf8E4M3FNUZ_into_DYNxDYNxf32_2_2_2_acc_4() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 2x2x2"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 2 : i64
+  %lhs_dim1 = arith.constant 2 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 12 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 2 : i64
+  %rhs_dim1 = arith.constant 2 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 13 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 2 : i64
+  %acc_dim1 = arith.constant 2 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 14 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 2 : i64
+  %acc_copy_dim1 = arith.constant 2 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 14 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxf8E4M3FNUZ_times_DYNxDYNxf8E4M3FNUZ_into_DYNxDYNxf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 2 : i64
+  %k = arith.constant 2 : i64
+  %n = arith.constant 2 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_2x2xf8E4M3FNUZ_times_2x2xf8E4M3FNUZ_into_2x2xf32_2_2_2_acc_5() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 2x2x2"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 2 : i64
+  %lhs_dim1 = arith.constant 2 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 15 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 2 : i64
+  %rhs_dim1 = arith.constant 2 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 16 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 2 : i64
+  %acc_dim1 = arith.constant 2 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 17 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 2 : i64
+  %acc_copy_dim1 = arith.constant 2 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 17 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_2x2xf8E4M3FNUZ_times_2x2xf8E4M3FNUZ_into_2x2xf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 2 : i64
+  %k = arith.constant 2 : i64
+  %n = arith.constant 2 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_DYNxDYNxf8E4M3FNUZ_times_DYNxDYNxf8E4M3FNUZ_into_DYNxDYNxf32_4_4_4_acc_6() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 4x4x4"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 4 : i64
+  %lhs_dim1 = arith.constant 4 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 18 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 4 : i64
+  %rhs_dim1 = arith.constant 4 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 19 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 4 : i64
+  %acc_dim1 = arith.constant 4 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 20 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 4 : i64
+  %acc_copy_dim1 = arith.constant 4 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 20 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxf8E4M3FNUZ_times_DYNxDYNxf8E4M3FNUZ_into_DYNxDYNxf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 4 : i64
+  %k = arith.constant 4 : i64
+  %n = arith.constant 4 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_4x4xf8E4M3FNUZ_times_4x4xf8E4M3FNUZ_into_4x4xf32_4_4_4_acc_7() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 4x4x4"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 4 : i64
+  %lhs_dim1 = arith.constant 4 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 21 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 4 : i64
+  %rhs_dim1 = arith.constant 4 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 22 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 4 : i64
+  %acc_dim1 = arith.constant 4 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 23 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 4 : i64
+  %acc_copy_dim1 = arith.constant 4 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 23 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_4x4xf8E4M3FNUZ_times_4x4xf8E4M3FNUZ_into_4x4xf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 4 : i64
+  %k = arith.constant 4 : i64
+  %n = arith.constant 4 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_DYNxDYNxf8E4M3FNUZ_times_DYNxDYNxf8E4M3FNUZ_into_DYNxDYNxf32_8_8_8_acc_8() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 8x8x8"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 8 : i64
+  %lhs_dim1 = arith.constant 8 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 24 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 8 : i64
+  %rhs_dim1 = arith.constant 8 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 25 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 8 : i64
+  %acc_dim1 = arith.constant 8 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 26 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 8 : i64
+  %acc_copy_dim1 = arith.constant 8 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 26 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxf8E4M3FNUZ_times_DYNxDYNxf8E4M3FNUZ_into_DYNxDYNxf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 8 : i64
+  %k = arith.constant 8 : i64
+  %n = arith.constant 8 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_8x8xf8E4M3FNUZ_times_8x8xf8E4M3FNUZ_into_8x8xf32_8_8_8_acc_9() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 8x8x8"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 8 : i64
+  %lhs_dim1 = arith.constant 8 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 27 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 8 : i64
+  %rhs_dim1 = arith.constant 8 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 28 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 8 : i64
+  %acc_dim1 = arith.constant 8 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 29 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 8 : i64
+  %acc_copy_dim1 = arith.constant 8 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 29 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_8x8xf8E4M3FNUZ_times_8x8xf8E4M3FNUZ_into_8x8xf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 8 : i64
+  %k = arith.constant 8 : i64
+  %n = arith.constant 8 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_DYNxDYNxf8E4M3FNUZ_times_DYNxDYNxf8E4M3FNUZ_into_DYNxDYNxf32_9_9_9_acc_10() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 9x9x9"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 9 : i64
+  %lhs_dim1 = arith.constant 9 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 30 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 9 : i64
+  %rhs_dim1 = arith.constant 9 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 31 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 9 : i64
+  %acc_dim1 = arith.constant 9 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 32 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 9 : i64
+  %acc_copy_dim1 = arith.constant 9 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 32 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxf8E4M3FNUZ_times_DYNxDYNxf8E4M3FNUZ_into_DYNxDYNxf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 9 : i64
+  %k = arith.constant 9 : i64
+  %n = arith.constant 9 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_9x9xf8E4M3FNUZ_times_9x9xf8E4M3FNUZ_into_9x9xf32_9_9_9_acc_11() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 9x9x9"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 9 : i64
+  %lhs_dim1 = arith.constant 9 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 33 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 9 : i64
+  %rhs_dim1 = arith.constant 9 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 34 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 9 : i64
+  %acc_dim1 = arith.constant 9 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 35 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 9 : i64
+  %acc_copy_dim1 = arith.constant 9 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 35 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_9x9xf8E4M3FNUZ_times_9x9xf8E4M3FNUZ_into_9x9xf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 9 : i64
+  %k = arith.constant 9 : i64
+  %n = arith.constant 9 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_DYNxDYNxf8E4M3FNUZ_times_DYNxDYNxf8E4M3FNUZ_into_DYNxDYNxf32_6_13_3_acc_12() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 6x13x3"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 6 : i64
+  %lhs_dim1 = arith.constant 13 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 36 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 13 : i64
+  %rhs_dim1 = arith.constant 3 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 37 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 6 : i64
+  %acc_dim1 = arith.constant 3 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 38 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 6 : i64
+  %acc_copy_dim1 = arith.constant 3 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 38 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxf8E4M3FNUZ_times_DYNxDYNxf8E4M3FNUZ_into_DYNxDYNxf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 6 : i64
+  %k = arith.constant 13 : i64
+  %n = arith.constant 3 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_6x13xf8E4M3FNUZ_times_13x3xf8E4M3FNUZ_into_6x3xf32_6_13_3_acc_13() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 6x13x3"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 6 : i64
+  %lhs_dim1 = arith.constant 13 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 39 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 13 : i64
+  %rhs_dim1 = arith.constant 3 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 40 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 6 : i64
+  %acc_dim1 = arith.constant 3 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 41 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 6 : i64
+  %acc_copy_dim1 = arith.constant 3 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 41 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_6x13xf8E4M3FNUZ_times_13x3xf8E4M3FNUZ_into_6x3xf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 6 : i64
+  %k = arith.constant 13 : i64
+  %n = arith.constant 3 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_DYNxDYNxf8E4M3FNUZ_times_DYNxDYNxf8E4M3FNUZ_into_DYNxDYNxf32_15_37_7_14() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 15x37x7"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 15 : i64
+  %lhs_dim1 = arith.constant 37 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 42 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 37 : i64
+  %rhs_dim1 = arith.constant 7 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 43 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_DYNxDYNxf8E4M3FNUZ_times_DYNxDYNxf8E4M3FNUZ_into_DYNxDYNxf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 15 : i64
+  %k = arith.constant 37 : i64
+  %n = arith.constant 7 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_15x37xf8E4M3FNUZ_times_37x7xf8E4M3FNUZ_into_15x7xf32_15_37_7_15() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 15x37x7"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 15 : i64
+  %lhs_dim1 = arith.constant 37 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 44 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 37 : i64
+  %rhs_dim1 = arith.constant 7 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 45 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_15x37xf8E4M3FNUZ_times_37x7xf8E4M3FNUZ_into_15x7xf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 15 : i64
+  %k = arith.constant 37 : i64
+  %n = arith.constant 7 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_DYNxDYNxf8E4M3FNUZ_times_DYNxDYNxf8E4M3FNUZ_into_DYNxDYNxf32_81_19_41_acc_16() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 81x19x41"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 81 : i64
+  %lhs_dim1 = arith.constant 19 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 46 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 19 : i64
+  %rhs_dim1 = arith.constant 41 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 47 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 81 : i64
+  %acc_dim1 = arith.constant 41 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 48 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 81 : i64
+  %acc_copy_dim1 = arith.constant 41 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 48 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxf8E4M3FNUZ_times_DYNxDYNxf8E4M3FNUZ_into_DYNxDYNxf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 81 : i64
+  %k = arith.constant 19 : i64
+  %n = arith.constant 41 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_81x19xf8E4M3FNUZ_times_19x41xf8E4M3FNUZ_into_81x41xf32_81_19_41_acc_17() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 81x19x41"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 81 : i64
+  %lhs_dim1 = arith.constant 19 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 49 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 19 : i64
+  %rhs_dim1 = arith.constant 41 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 50 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 81 : i64
+  %acc_dim1 = arith.constant 41 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 51 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 81 : i64
+  %acc_copy_dim1 = arith.constant 41 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 51 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_81x19xf8E4M3FNUZ_times_19x41xf8E4M3FNUZ_into_81x41xf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 81 : i64
+  %k = arith.constant 19 : i64
+  %n = arith.constant 41 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_DYNxDYNxf8E4M3FNUZ_times_DYNxDYNxf8E4M3FNUZ_into_DYNxDYNxf32_1_10_10_acc_18() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1x10x10"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1 : i64
+  %lhs_dim1 = arith.constant 10 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 52 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 10 : i64
+  %rhs_dim1 = arith.constant 10 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 53 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 1 : i64
+  %acc_dim1 = arith.constant 10 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 54 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 1 : i64
+  %acc_copy_dim1 = arith.constant 10 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 54 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxf8E4M3FNUZ_times_DYNxDYNxf8E4M3FNUZ_into_DYNxDYNxf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1 : i64
+  %k = arith.constant 10 : i64
+  %n = arith.constant 10 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_1x10xf8E4M3FNUZ_times_10x10xf8E4M3FNUZ_into_1x10xf32_1_10_10_acc_19() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1x10x10"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1 : i64
+  %lhs_dim1 = arith.constant 10 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 55 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 10 : i64
+  %rhs_dim1 = arith.constant 10 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 56 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 1 : i64
+  %acc_dim1 = arith.constant 10 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 57 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 1 : i64
+  %acc_copy_dim1 = arith.constant 10 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 57 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_1x10xf8E4M3FNUZ_times_10x10xf8E4M3FNUZ_into_1x10xf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1 : i64
+  %k = arith.constant 10 : i64
+  %n = arith.constant 10 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_DYNxDYNxf8E4M3FNUZ_times_DYNxDYNxf8E4M3FNUZ_into_DYNxDYNxf32_1_10_10_20() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1x10x10"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1 : i64
+  %lhs_dim1 = arith.constant 10 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 58 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 10 : i64
+  %rhs_dim1 = arith.constant 10 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 59 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_DYNxDYNxf8E4M3FNUZ_times_DYNxDYNxf8E4M3FNUZ_into_DYNxDYNxf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1 : i64
+  %k = arith.constant 10 : i64
+  %n = arith.constant 10 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_1x10xf8E4M3FNUZ_times_10x10xf8E4M3FNUZ_into_1x10xf32_1_10_10_21() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1x10x10"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1 : i64
+  %lhs_dim1 = arith.constant 10 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 60 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 10 : i64
+  %rhs_dim1 = arith.constant 10 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 61 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_1x10xf8E4M3FNUZ_times_10x10xf8E4M3FNUZ_into_1x10xf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1 : i64
+  %k = arith.constant 10 : i64
+  %n = arith.constant 10 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_DYNxDYNxf8E4M3FNUZ_times_DYNxDYNxf8E4M3FNUZ_into_DYNxDYNxf32_10_1_10_acc_22() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 10x1x10"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 10 : i64
+  %lhs_dim1 = arith.constant 1 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 62 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1 : i64
+  %rhs_dim1 = arith.constant 10 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 63 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 10 : i64
+  %acc_dim1 = arith.constant 10 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 64 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 10 : i64
+  %acc_copy_dim1 = arith.constant 10 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 64 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxf8E4M3FNUZ_times_DYNxDYNxf8E4M3FNUZ_into_DYNxDYNxf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 10 : i64
+  %k = arith.constant 1 : i64
+  %n = arith.constant 10 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_10x1xf8E4M3FNUZ_times_1x10xf8E4M3FNUZ_into_10x10xf32_10_1_10_acc_23() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 10x1x10"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 10 : i64
+  %lhs_dim1 = arith.constant 1 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 65 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1 : i64
+  %rhs_dim1 = arith.constant 10 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 66 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 10 : i64
+  %acc_dim1 = arith.constant 10 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 67 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 10 : i64
+  %acc_copy_dim1 = arith.constant 10 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 67 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_10x1xf8E4M3FNUZ_times_1x10xf8E4M3FNUZ_into_10x10xf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 10 : i64
+  %k = arith.constant 1 : i64
+  %n = arith.constant 10 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_DYNxDYNxf8E4M3FNUZ_times_DYNxDYNxf8E4M3FNUZ_into_DYNxDYNxf32_10_10_1_acc_24() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 10x10x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 10 : i64
+  %lhs_dim1 = arith.constant 10 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 68 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 10 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 69 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 10 : i64
+  %acc_dim1 = arith.constant 1 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 70 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 10 : i64
+  %acc_copy_dim1 = arith.constant 1 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 70 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxf8E4M3FNUZ_times_DYNxDYNxf8E4M3FNUZ_into_DYNxDYNxf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 10 : i64
+  %k = arith.constant 10 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_10x10xf8E4M3FNUZ_times_10x1xf8E4M3FNUZ_into_10x1xf32_10_10_1_acc_25() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 10x10x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 10 : i64
+  %lhs_dim1 = arith.constant 10 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 71 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 10 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 72 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 10 : i64
+  %acc_dim1 = arith.constant 1 : i64
+  %acc_element_type = hal.element_type<f32> : i32
+  %acc_seed = arith.constant 73 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 10 : i64
+  %acc_copy_dim1 = arith.constant 1 : i64
+  %acc_copy_element_type = hal.element_type<f32> : i32
+  %acc_copy_seed = arith.constant 73 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_10x10xf8E4M3FNUZ_times_10x1xf8E4M3FNUZ_into_10x1xf32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 10 : i64
+  %k = arith.constant 10 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_DYNxDYNxf8E4M3FNUZ_times_DYNxDYNxf8E4M3FNUZ_into_DYNxDYNxf32_10_10_1_26() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 10x10x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 10 : i64
+  %lhs_dim1 = arith.constant 10 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 74 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 10 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 75 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_DYNxDYNxf8E4M3FNUZ_times_DYNxDYNxf8E4M3FNUZ_into_DYNxDYNxf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 10 : i64
+  %k = arith.constant 10 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_10x10xf8E4M3FNUZ_times_10x1xf8E4M3FNUZ_into_10x1xf32_10_10_1_27() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 10x10x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 10 : i64
+  %lhs_dim1 = arith.constant 10 : i64
+  %lhs_element_type = hal.element_type<f32> : i32
+  %lhs_seed = arith.constant 76 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 10 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<f32> : i32
+  %rhs_seed = arith.constant 77 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_10x10xf8E4M3FNUZ_times_10x1xf8E4M3FNUZ_into_10x1xf32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 10 : i64
+  %k = arith.constant 10 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+
+}

--- a/matmul/tests/generated/matmul_f8E4M3FNUZ_f32_small_matmul.mlir
+++ b/matmul/tests/generated/matmul_f8E4M3FNUZ_f32_small_matmul.mlir
@@ -1,0 +1,115 @@
+func.func @matmul_accumulate_DYNxDYNxf8E4M3FNUZ_times_DYNxDYNxf8E4M3FNUZ_into_DYNxDYNxf32(%lhs: tensor<?x?xf32>, %rhs: tensor<?x?xf32>, %acc: tensor<?x?xf32>) -> tensor<?x?xf32> {
+  %lhs_casted = arith.truncf %lhs: tensor<?x?xf32> to tensor<?x?xf8E4M3FNUZ>
+  %rhs_casted = arith.truncf %rhs: tensor<?x?xf32> to tensor<?x?xf8E4M3FNUZ>
+  %result = linalg.matmul ins(%lhs_casted, %rhs_casted: tensor<?x?xf8E4M3FNUZ>, tensor<?x?xf8E4M3FNUZ>) outs(%acc: tensor<?x?xf32>) -> tensor<?x?xf32>  return %result: tensor<?x?xf32>
+}
+
+func.func @matmul_accumulate_1x1xf8E4M3FNUZ_times_1x1xf8E4M3FNUZ_into_1x1xf32(%lhs: tensor<1x1xf32>, %rhs: tensor<1x1xf32>, %acc: tensor<1x1xf32>) -> tensor<1x1xf32> {
+  %lhs_casted = arith.truncf %lhs: tensor<1x1xf32> to tensor<1x1xf8E4M3FNUZ>
+  %rhs_casted = arith.truncf %rhs: tensor<1x1xf32> to tensor<1x1xf8E4M3FNUZ>
+  %result = linalg.matmul ins(%lhs_casted, %rhs_casted: tensor<1x1xf8E4M3FNUZ>, tensor<1x1xf8E4M3FNUZ>) outs(%acc: tensor<1x1xf32>) -> tensor<1x1xf32>  return %result: tensor<1x1xf32>
+}
+
+func.func @matmul_DYNxDYNxf8E4M3FNUZ_times_DYNxDYNxf8E4M3FNUZ_into_DYNxDYNxf32(%lhs: tensor<?x?xf32>, %rhs: tensor<?x?xf32>) -> tensor<?x?xf32> {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %acc_dim0 = tensor.dim %lhs, %c0 : tensor<?x?xf32>
+  %acc_dim1 = tensor.dim %rhs, %c1 : tensor<?x?xf32>
+  %init_acc = tensor.empty(%acc_dim0, %acc_dim1) : tensor<?x?xf32>
+  %c0_acc_type = arith.constant 0.0: f32
+  %acc = linalg.fill ins(%c0_acc_type : f32) outs(%init_acc : tensor<?x?xf32>) -> tensor<?x?xf32>
+  %lhs_casted = arith.truncf %lhs: tensor<?x?xf32> to tensor<?x?xf8E4M3FNUZ>
+  %rhs_casted = arith.truncf %rhs: tensor<?x?xf32> to tensor<?x?xf8E4M3FNUZ>
+  %result = linalg.matmul ins(%lhs_casted, %rhs_casted: tensor<?x?xf8E4M3FNUZ>, tensor<?x?xf8E4M3FNUZ>) outs(%acc: tensor<?x?xf32>) -> tensor<?x?xf32>  return %result: tensor<?x?xf32>
+}
+
+func.func @matmul_1x1xf8E4M3FNUZ_times_1x1xf8E4M3FNUZ_into_1x1xf32(%lhs: tensor<1x1xf32>, %rhs: tensor<1x1xf32>) -> tensor<1x1xf32> {
+  %init_acc = tensor.empty() : tensor<1x1xf32>
+  %c0_acc_type = arith.constant 0.0: f32
+  %acc = linalg.fill ins(%c0_acc_type : f32) outs(%init_acc : tensor<1x1xf32>) -> tensor<1x1xf32>
+  %lhs_casted = arith.truncf %lhs: tensor<1x1xf32> to tensor<1x1xf8E4M3FNUZ>
+  %rhs_casted = arith.truncf %rhs: tensor<1x1xf32> to tensor<1x1xf8E4M3FNUZ>
+  %result = linalg.matmul ins(%lhs_casted, %rhs_casted: tensor<1x1xf8E4M3FNUZ>, tensor<1x1xf8E4M3FNUZ>) outs(%acc: tensor<1x1xf32>) -> tensor<1x1xf32>  return %result: tensor<1x1xf32>
+}
+
+func.func @matmul_accumulate_2x2xf8E4M3FNUZ_times_2x2xf8E4M3FNUZ_into_2x2xf32(%lhs: tensor<2x2xf32>, %rhs: tensor<2x2xf32>, %acc: tensor<2x2xf32>) -> tensor<2x2xf32> {
+  %lhs_casted = arith.truncf %lhs: tensor<2x2xf32> to tensor<2x2xf8E4M3FNUZ>
+  %rhs_casted = arith.truncf %rhs: tensor<2x2xf32> to tensor<2x2xf8E4M3FNUZ>
+  %result = linalg.matmul ins(%lhs_casted, %rhs_casted: tensor<2x2xf8E4M3FNUZ>, tensor<2x2xf8E4M3FNUZ>) outs(%acc: tensor<2x2xf32>) -> tensor<2x2xf32>  return %result: tensor<2x2xf32>
+}
+
+func.func @matmul_accumulate_4x4xf8E4M3FNUZ_times_4x4xf8E4M3FNUZ_into_4x4xf32(%lhs: tensor<4x4xf32>, %rhs: tensor<4x4xf32>, %acc: tensor<4x4xf32>) -> tensor<4x4xf32> {
+  %lhs_casted = arith.truncf %lhs: tensor<4x4xf32> to tensor<4x4xf8E4M3FNUZ>
+  %rhs_casted = arith.truncf %rhs: tensor<4x4xf32> to tensor<4x4xf8E4M3FNUZ>
+  %result = linalg.matmul ins(%lhs_casted, %rhs_casted: tensor<4x4xf8E4M3FNUZ>, tensor<4x4xf8E4M3FNUZ>) outs(%acc: tensor<4x4xf32>) -> tensor<4x4xf32>  return %result: tensor<4x4xf32>
+}
+
+func.func @matmul_accumulate_8x8xf8E4M3FNUZ_times_8x8xf8E4M3FNUZ_into_8x8xf32(%lhs: tensor<8x8xf32>, %rhs: tensor<8x8xf32>, %acc: tensor<8x8xf32>) -> tensor<8x8xf32> {
+  %lhs_casted = arith.truncf %lhs: tensor<8x8xf32> to tensor<8x8xf8E4M3FNUZ>
+  %rhs_casted = arith.truncf %rhs: tensor<8x8xf32> to tensor<8x8xf8E4M3FNUZ>
+  %result = linalg.matmul ins(%lhs_casted, %rhs_casted: tensor<8x8xf8E4M3FNUZ>, tensor<8x8xf8E4M3FNUZ>) outs(%acc: tensor<8x8xf32>) -> tensor<8x8xf32>  return %result: tensor<8x8xf32>
+}
+
+func.func @matmul_accumulate_9x9xf8E4M3FNUZ_times_9x9xf8E4M3FNUZ_into_9x9xf32(%lhs: tensor<9x9xf32>, %rhs: tensor<9x9xf32>, %acc: tensor<9x9xf32>) -> tensor<9x9xf32> {
+  %lhs_casted = arith.truncf %lhs: tensor<9x9xf32> to tensor<9x9xf8E4M3FNUZ>
+  %rhs_casted = arith.truncf %rhs: tensor<9x9xf32> to tensor<9x9xf8E4M3FNUZ>
+  %result = linalg.matmul ins(%lhs_casted, %rhs_casted: tensor<9x9xf8E4M3FNUZ>, tensor<9x9xf8E4M3FNUZ>) outs(%acc: tensor<9x9xf32>) -> tensor<9x9xf32>  return %result: tensor<9x9xf32>
+}
+
+func.func @matmul_accumulate_6x13xf8E4M3FNUZ_times_13x3xf8E4M3FNUZ_into_6x3xf32(%lhs: tensor<6x13xf32>, %rhs: tensor<13x3xf32>, %acc: tensor<6x3xf32>) -> tensor<6x3xf32> {
+  %lhs_casted = arith.truncf %lhs: tensor<6x13xf32> to tensor<6x13xf8E4M3FNUZ>
+  %rhs_casted = arith.truncf %rhs: tensor<13x3xf32> to tensor<13x3xf8E4M3FNUZ>
+  %result = linalg.matmul ins(%lhs_casted, %rhs_casted: tensor<6x13xf8E4M3FNUZ>, tensor<13x3xf8E4M3FNUZ>) outs(%acc: tensor<6x3xf32>) -> tensor<6x3xf32>  return %result: tensor<6x3xf32>
+}
+
+func.func @matmul_15x37xf8E4M3FNUZ_times_37x7xf8E4M3FNUZ_into_15x7xf32(%lhs: tensor<15x37xf32>, %rhs: tensor<37x7xf32>) -> tensor<15x7xf32> {
+  %init_acc = tensor.empty() : tensor<15x7xf32>
+  %c0_acc_type = arith.constant 0.0: f32
+  %acc = linalg.fill ins(%c0_acc_type : f32) outs(%init_acc : tensor<15x7xf32>) -> tensor<15x7xf32>
+  %lhs_casted = arith.truncf %lhs: tensor<15x37xf32> to tensor<15x37xf8E4M3FNUZ>
+  %rhs_casted = arith.truncf %rhs: tensor<37x7xf32> to tensor<37x7xf8E4M3FNUZ>
+  %result = linalg.matmul ins(%lhs_casted, %rhs_casted: tensor<15x37xf8E4M3FNUZ>, tensor<37x7xf8E4M3FNUZ>) outs(%acc: tensor<15x7xf32>) -> tensor<15x7xf32>  return %result: tensor<15x7xf32>
+}
+
+func.func @matmul_accumulate_81x19xf8E4M3FNUZ_times_19x41xf8E4M3FNUZ_into_81x41xf32(%lhs: tensor<81x19xf32>, %rhs: tensor<19x41xf32>, %acc: tensor<81x41xf32>) -> tensor<81x41xf32> {
+  %lhs_casted = arith.truncf %lhs: tensor<81x19xf32> to tensor<81x19xf8E4M3FNUZ>
+  %rhs_casted = arith.truncf %rhs: tensor<19x41xf32> to tensor<19x41xf8E4M3FNUZ>
+  %result = linalg.matmul ins(%lhs_casted, %rhs_casted: tensor<81x19xf8E4M3FNUZ>, tensor<19x41xf8E4M3FNUZ>) outs(%acc: tensor<81x41xf32>) -> tensor<81x41xf32>  return %result: tensor<81x41xf32>
+}
+
+func.func @matmul_accumulate_1x10xf8E4M3FNUZ_times_10x10xf8E4M3FNUZ_into_1x10xf32(%lhs: tensor<1x10xf32>, %rhs: tensor<10x10xf32>, %acc: tensor<1x10xf32>) -> tensor<1x10xf32> {
+  %lhs_casted = arith.truncf %lhs: tensor<1x10xf32> to tensor<1x10xf8E4M3FNUZ>
+  %rhs_casted = arith.truncf %rhs: tensor<10x10xf32> to tensor<10x10xf8E4M3FNUZ>
+  %result = linalg.matmul ins(%lhs_casted, %rhs_casted: tensor<1x10xf8E4M3FNUZ>, tensor<10x10xf8E4M3FNUZ>) outs(%acc: tensor<1x10xf32>) -> tensor<1x10xf32>  return %result: tensor<1x10xf32>
+}
+
+func.func @matmul_1x10xf8E4M3FNUZ_times_10x10xf8E4M3FNUZ_into_1x10xf32(%lhs: tensor<1x10xf32>, %rhs: tensor<10x10xf32>) -> tensor<1x10xf32> {
+  %init_acc = tensor.empty() : tensor<1x10xf32>
+  %c0_acc_type = arith.constant 0.0: f32
+  %acc = linalg.fill ins(%c0_acc_type : f32) outs(%init_acc : tensor<1x10xf32>) -> tensor<1x10xf32>
+  %lhs_casted = arith.truncf %lhs: tensor<1x10xf32> to tensor<1x10xf8E4M3FNUZ>
+  %rhs_casted = arith.truncf %rhs: tensor<10x10xf32> to tensor<10x10xf8E4M3FNUZ>
+  %result = linalg.matmul ins(%lhs_casted, %rhs_casted: tensor<1x10xf8E4M3FNUZ>, tensor<10x10xf8E4M3FNUZ>) outs(%acc: tensor<1x10xf32>) -> tensor<1x10xf32>  return %result: tensor<1x10xf32>
+}
+
+func.func @matmul_accumulate_10x1xf8E4M3FNUZ_times_1x10xf8E4M3FNUZ_into_10x10xf32(%lhs: tensor<10x1xf32>, %rhs: tensor<1x10xf32>, %acc: tensor<10x10xf32>) -> tensor<10x10xf32> {
+  %lhs_casted = arith.truncf %lhs: tensor<10x1xf32> to tensor<10x1xf8E4M3FNUZ>
+  %rhs_casted = arith.truncf %rhs: tensor<1x10xf32> to tensor<1x10xf8E4M3FNUZ>
+  %result = linalg.matmul ins(%lhs_casted, %rhs_casted: tensor<10x1xf8E4M3FNUZ>, tensor<1x10xf8E4M3FNUZ>) outs(%acc: tensor<10x10xf32>) -> tensor<10x10xf32>  return %result: tensor<10x10xf32>
+}
+
+func.func @matmul_accumulate_10x10xf8E4M3FNUZ_times_10x1xf8E4M3FNUZ_into_10x1xf32(%lhs: tensor<10x10xf32>, %rhs: tensor<10x1xf32>, %acc: tensor<10x1xf32>) -> tensor<10x1xf32> {
+  %lhs_casted = arith.truncf %lhs: tensor<10x10xf32> to tensor<10x10xf8E4M3FNUZ>
+  %rhs_casted = arith.truncf %rhs: tensor<10x1xf32> to tensor<10x1xf8E4M3FNUZ>
+  %result = linalg.matmul ins(%lhs_casted, %rhs_casted: tensor<10x10xf8E4M3FNUZ>, tensor<10x1xf8E4M3FNUZ>) outs(%acc: tensor<10x1xf32>) -> tensor<10x1xf32>  return %result: tensor<10x1xf32>
+}
+
+func.func @matmul_10x10xf8E4M3FNUZ_times_10x1xf8E4M3FNUZ_into_10x1xf32(%lhs: tensor<10x10xf32>, %rhs: tensor<10x1xf32>) -> tensor<10x1xf32> {
+  %init_acc = tensor.empty() : tensor<10x1xf32>
+  %c0_acc_type = arith.constant 0.0: f32
+  %acc = linalg.fill ins(%c0_acc_type : f32) outs(%init_acc : tensor<10x1xf32>) -> tensor<10x1xf32>
+  %lhs_casted = arith.truncf %lhs: tensor<10x10xf32> to tensor<10x10xf8E4M3FNUZ>
+  %rhs_casted = arith.truncf %rhs: tensor<10x1xf32> to tensor<10x1xf8E4M3FNUZ>
+  %result = linalg.matmul ins(%lhs_casted, %rhs_casted: tensor<10x10xf8E4M3FNUZ>, tensor<10x1xf8E4M3FNUZ>) outs(%acc: tensor<10x1xf32>) -> tensor<10x1xf32>  return %result: tensor<10x1xf32>
+}
+

--- a/matmul/tests/generated/matmul_i8_i32_gpu_large_aligned_calls.mlir
+++ b/matmul/tests/generated/matmul_i8_i32_gpu_large_aligned_calls.mlir
@@ -1,0 +1,71 @@
+builtin.module @calls attributes {
+  
+} {
+
+func.func private @matmul_test.generate_random_matrix(%device: !hal.device, %dim0: i64, %dim1: i64, %element_type: i32, %seed: i32) -> !hal.buffer_view
+func.func private @matmul_test.check_matmul_results(%device: !hal.device, %m: i64, %k: i64, %n: i64, %transpose_rhs: i32, %lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view, %actual_result: !hal.buffer_view)
+
+func.func private @module.matmul_accumulate_512x128xi8_times_128x512xi8_into_512x512xi32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_512x128xi8_times_128x512xi8_into_512x512xi32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+
+func.func @matmul_accumulate_512x128xi8_times_128x512xi8_into_512x512xi32_512_128_512_acc_0() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 512x128x512"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 512 : i64
+  %lhs_dim1 = arith.constant 128 : i64
+  %lhs_element_type = hal.element_type<i8> : i32
+  %lhs_seed = arith.constant 2 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 128 : i64
+  %rhs_dim1 = arith.constant 512 : i64
+  %rhs_element_type = hal.element_type<i8> : i32
+  %rhs_seed = arith.constant 3 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 512 : i64
+  %acc_dim1 = arith.constant 512 : i64
+  %acc_element_type = hal.element_type<i32> : i32
+  %acc_seed = arith.constant 4 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 512 : i64
+  %acc_copy_dim1 = arith.constant 512 : i64
+  %acc_copy_element_type = hal.element_type<i32> : i32
+  %acc_copy_seed = arith.constant 4 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_512x128xi8_times_128x512xi8_into_512x512xi32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 512 : i64
+  %k = arith.constant 128 : i64
+  %n = arith.constant 512 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_512x128xi8_times_128x512xi8_into_512x512xi32_512_128_512_1() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 512x128x512"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 512 : i64
+  %lhs_dim1 = arith.constant 128 : i64
+  %lhs_element_type = hal.element_type<i8> : i32
+  %lhs_seed = arith.constant 5 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 128 : i64
+  %rhs_dim1 = arith.constant 512 : i64
+  %rhs_element_type = hal.element_type<i8> : i32
+  %rhs_seed = arith.constant 6 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_512x128xi8_times_128x512xi8_into_512x512xi32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 512 : i64
+  %k = arith.constant 128 : i64
+  %n = arith.constant 512 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+
+}

--- a/matmul/tests/generated/matmul_i8_i32_gpu_large_aligned_matmul.mlir
+++ b/matmul/tests/generated/matmul_i8_i32_gpu_large_aligned_matmul.mlir
@@ -1,0 +1,13 @@
+func.func @matmul_accumulate_512x128xi8_times_128x512xi8_into_512x512xi32(%lhs: tensor<512x128xi8>, %rhs: tensor<128x512xi8>, %acc: tensor<512x512xi32>) -> tensor<512x512xi32> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<512x128xi8>, tensor<128x512xi8>) outs(%acc: tensor<512x512xi32>) -> tensor<512x512xi32>
+  return %result: tensor<512x512xi32>
+}
+
+func.func @matmul_512x128xi8_times_128x512xi8_into_512x512xi32(%lhs: tensor<512x128xi8>, %rhs: tensor<128x512xi8>) -> tensor<512x512xi32> {
+  %init_acc = tensor.empty() : tensor<512x512xi32>
+  %c0_acc_type = arith.constant 0: i32
+  %acc = linalg.fill ins(%c0_acc_type : i32) outs(%init_acc : tensor<512x512xi32>) -> tensor<512x512xi32>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<512x128xi8>, tensor<128x512xi8>) outs(%acc: tensor<512x512xi32>) -> tensor<512x512xi32>
+  return %result: tensor<512x512xi32>
+}
+

--- a/matmul/tests/generated/matmul_i8_i32_gpu_large_calls.mlir
+++ b/matmul/tests/generated/matmul_i8_i32_gpu_large_calls.mlir
@@ -1,0 +1,270 @@
+builtin.module @calls attributes {
+  
+} {
+
+func.func private @matmul_test.generate_random_matrix(%device: !hal.device, %dim0: i64, %dim1: i64, %element_type: i32, %seed: i32) -> !hal.buffer_view
+func.func private @matmul_test.check_matmul_results(%device: !hal.device, %m: i64, %k: i64, %n: i64, %transpose_rhs: i32, %lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view, %actual_result: !hal.buffer_view)
+
+func.func private @module.matmul_457x330xi8_times_330x512xi8_into_457x512xi32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_457x330xi8_times_330x514xi8_into_457x514xi32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_438x330xi8_times_330x514xi8_into_438x514xi32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_540x332xi8_times_332x516xi8_into_540x516xi32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_1000x4xi8_times_4x512xi8_into_1000x512xi32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_4x1000xi8_times_1000x512xi8_into_4x512xi32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_512x1000xi8_times_1000x4xi8_into_512x4xi32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_512x128xi8_times_128x500xi8_into_512x500xi32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_457x160xi8_times_160x512xi8_into_457x512xi32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_512x330xi8_times_330x512xi8_into_512x512xi32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+
+func.func @matmul_457x330xi8_times_330x512xi8_into_457x512xi32_457_330_512_0() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 457x330x512"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 457 : i64
+  %lhs_dim1 = arith.constant 330 : i64
+  %lhs_element_type = hal.element_type<i8> : i32
+  %lhs_seed = arith.constant 2 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 330 : i64
+  %rhs_dim1 = arith.constant 512 : i64
+  %rhs_element_type = hal.element_type<i8> : i32
+  %rhs_seed = arith.constant 3 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_457x330xi8_times_330x512xi8_into_457x512xi32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 457 : i64
+  %k = arith.constant 330 : i64
+  %n = arith.constant 512 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_457x330xi8_times_330x514xi8_into_457x514xi32_457_330_514_1() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 457x330x514"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 457 : i64
+  %lhs_dim1 = arith.constant 330 : i64
+  %lhs_element_type = hal.element_type<i8> : i32
+  %lhs_seed = arith.constant 4 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 330 : i64
+  %rhs_dim1 = arith.constant 514 : i64
+  %rhs_element_type = hal.element_type<i8> : i32
+  %rhs_seed = arith.constant 5 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_457x330xi8_times_330x514xi8_into_457x514xi32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 457 : i64
+  %k = arith.constant 330 : i64
+  %n = arith.constant 514 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_438x330xi8_times_330x514xi8_into_438x514xi32_438_330_514_2() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 438x330x514"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 438 : i64
+  %lhs_dim1 = arith.constant 330 : i64
+  %lhs_element_type = hal.element_type<i8> : i32
+  %lhs_seed = arith.constant 6 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 330 : i64
+  %rhs_dim1 = arith.constant 514 : i64
+  %rhs_element_type = hal.element_type<i8> : i32
+  %rhs_seed = arith.constant 7 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_438x330xi8_times_330x514xi8_into_438x514xi32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 438 : i64
+  %k = arith.constant 330 : i64
+  %n = arith.constant 514 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_540x332xi8_times_332x516xi8_into_540x516xi32_540_332_516_3() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 540x332x516"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 540 : i64
+  %lhs_dim1 = arith.constant 332 : i64
+  %lhs_element_type = hal.element_type<i8> : i32
+  %lhs_seed = arith.constant 8 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 332 : i64
+  %rhs_dim1 = arith.constant 516 : i64
+  %rhs_element_type = hal.element_type<i8> : i32
+  %rhs_seed = arith.constant 9 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_540x332xi8_times_332x516xi8_into_540x516xi32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 540 : i64
+  %k = arith.constant 332 : i64
+  %n = arith.constant 516 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_1000x4xi8_times_4x512xi8_into_1000x512xi32_1000_4_512_4() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1000x4x512"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1000 : i64
+  %lhs_dim1 = arith.constant 4 : i64
+  %lhs_element_type = hal.element_type<i8> : i32
+  %lhs_seed = arith.constant 10 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 4 : i64
+  %rhs_dim1 = arith.constant 512 : i64
+  %rhs_element_type = hal.element_type<i8> : i32
+  %rhs_seed = arith.constant 11 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_1000x4xi8_times_4x512xi8_into_1000x512xi32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1000 : i64
+  %k = arith.constant 4 : i64
+  %n = arith.constant 512 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_4x1000xi8_times_1000x512xi8_into_4x512xi32_4_1000_512_5() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 4x1000x512"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 4 : i64
+  %lhs_dim1 = arith.constant 1000 : i64
+  %lhs_element_type = hal.element_type<i8> : i32
+  %lhs_seed = arith.constant 12 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1000 : i64
+  %rhs_dim1 = arith.constant 512 : i64
+  %rhs_element_type = hal.element_type<i8> : i32
+  %rhs_seed = arith.constant 13 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_4x1000xi8_times_1000x512xi8_into_4x512xi32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 4 : i64
+  %k = arith.constant 1000 : i64
+  %n = arith.constant 512 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_512x1000xi8_times_1000x4xi8_into_512x4xi32_512_1000_4_6() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 512x1000x4"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 512 : i64
+  %lhs_dim1 = arith.constant 1000 : i64
+  %lhs_element_type = hal.element_type<i8> : i32
+  %lhs_seed = arith.constant 14 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1000 : i64
+  %rhs_dim1 = arith.constant 4 : i64
+  %rhs_element_type = hal.element_type<i8> : i32
+  %rhs_seed = arith.constant 15 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_512x1000xi8_times_1000x4xi8_into_512x4xi32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 512 : i64
+  %k = arith.constant 1000 : i64
+  %n = arith.constant 4 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_512x128xi8_times_128x500xi8_into_512x500xi32_512_128_500_7() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 512x128x500"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 512 : i64
+  %lhs_dim1 = arith.constant 128 : i64
+  %lhs_element_type = hal.element_type<i8> : i32
+  %lhs_seed = arith.constant 16 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 128 : i64
+  %rhs_dim1 = arith.constant 500 : i64
+  %rhs_element_type = hal.element_type<i8> : i32
+  %rhs_seed = arith.constant 17 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_512x128xi8_times_128x500xi8_into_512x500xi32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 512 : i64
+  %k = arith.constant 128 : i64
+  %n = arith.constant 500 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_457x160xi8_times_160x512xi8_into_457x512xi32_457_160_512_8() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 457x160x512"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 457 : i64
+  %lhs_dim1 = arith.constant 160 : i64
+  %lhs_element_type = hal.element_type<i8> : i32
+  %lhs_seed = arith.constant 18 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 160 : i64
+  %rhs_dim1 = arith.constant 512 : i64
+  %rhs_element_type = hal.element_type<i8> : i32
+  %rhs_seed = arith.constant 19 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_457x160xi8_times_160x512xi8_into_457x512xi32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 457 : i64
+  %k = arith.constant 160 : i64
+  %n = arith.constant 512 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_512x330xi8_times_330x512xi8_into_512x512xi32_512_330_512_9() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 512x330x512"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 512 : i64
+  %lhs_dim1 = arith.constant 330 : i64
+  %lhs_element_type = hal.element_type<i8> : i32
+  %lhs_seed = arith.constant 20 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 330 : i64
+  %rhs_dim1 = arith.constant 512 : i64
+  %rhs_element_type = hal.element_type<i8> : i32
+  %rhs_seed = arith.constant 21 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_512x330xi8_times_330x512xi8_into_512x512xi32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 512 : i64
+  %k = arith.constant 330 : i64
+  %n = arith.constant 512 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+
+}

--- a/matmul/tests/generated/matmul_i8_i32_gpu_large_matmul.mlir
+++ b/matmul/tests/generated/matmul_i8_i32_gpu_large_matmul.mlir
@@ -1,0 +1,80 @@
+func.func @matmul_457x330xi8_times_330x512xi8_into_457x512xi32(%lhs: tensor<457x330xi8>, %rhs: tensor<330x512xi8>) -> tensor<457x512xi32> {
+  %init_acc = tensor.empty() : tensor<457x512xi32>
+  %c0_acc_type = arith.constant 0: i32
+  %acc = linalg.fill ins(%c0_acc_type : i32) outs(%init_acc : tensor<457x512xi32>) -> tensor<457x512xi32>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<457x330xi8>, tensor<330x512xi8>) outs(%acc: tensor<457x512xi32>) -> tensor<457x512xi32>
+  return %result: tensor<457x512xi32>
+}
+
+func.func @matmul_457x330xi8_times_330x514xi8_into_457x514xi32(%lhs: tensor<457x330xi8>, %rhs: tensor<330x514xi8>) -> tensor<457x514xi32> {
+  %init_acc = tensor.empty() : tensor<457x514xi32>
+  %c0_acc_type = arith.constant 0: i32
+  %acc = linalg.fill ins(%c0_acc_type : i32) outs(%init_acc : tensor<457x514xi32>) -> tensor<457x514xi32>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<457x330xi8>, tensor<330x514xi8>) outs(%acc: tensor<457x514xi32>) -> tensor<457x514xi32>
+  return %result: tensor<457x514xi32>
+}
+
+func.func @matmul_438x330xi8_times_330x514xi8_into_438x514xi32(%lhs: tensor<438x330xi8>, %rhs: tensor<330x514xi8>) -> tensor<438x514xi32> {
+  %init_acc = tensor.empty() : tensor<438x514xi32>
+  %c0_acc_type = arith.constant 0: i32
+  %acc = linalg.fill ins(%c0_acc_type : i32) outs(%init_acc : tensor<438x514xi32>) -> tensor<438x514xi32>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<438x330xi8>, tensor<330x514xi8>) outs(%acc: tensor<438x514xi32>) -> tensor<438x514xi32>
+  return %result: tensor<438x514xi32>
+}
+
+func.func @matmul_540x332xi8_times_332x516xi8_into_540x516xi32(%lhs: tensor<540x332xi8>, %rhs: tensor<332x516xi8>) -> tensor<540x516xi32> {
+  %init_acc = tensor.empty() : tensor<540x516xi32>
+  %c0_acc_type = arith.constant 0: i32
+  %acc = linalg.fill ins(%c0_acc_type : i32) outs(%init_acc : tensor<540x516xi32>) -> tensor<540x516xi32>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<540x332xi8>, tensor<332x516xi8>) outs(%acc: tensor<540x516xi32>) -> tensor<540x516xi32>
+  return %result: tensor<540x516xi32>
+}
+
+func.func @matmul_1000x4xi8_times_4x512xi8_into_1000x512xi32(%lhs: tensor<1000x4xi8>, %rhs: tensor<4x512xi8>) -> tensor<1000x512xi32> {
+  %init_acc = tensor.empty() : tensor<1000x512xi32>
+  %c0_acc_type = arith.constant 0: i32
+  %acc = linalg.fill ins(%c0_acc_type : i32) outs(%init_acc : tensor<1000x512xi32>) -> tensor<1000x512xi32>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<1000x4xi8>, tensor<4x512xi8>) outs(%acc: tensor<1000x512xi32>) -> tensor<1000x512xi32>
+  return %result: tensor<1000x512xi32>
+}
+
+func.func @matmul_4x1000xi8_times_1000x512xi8_into_4x512xi32(%lhs: tensor<4x1000xi8>, %rhs: tensor<1000x512xi8>) -> tensor<4x512xi32> {
+  %init_acc = tensor.empty() : tensor<4x512xi32>
+  %c0_acc_type = arith.constant 0: i32
+  %acc = linalg.fill ins(%c0_acc_type : i32) outs(%init_acc : tensor<4x512xi32>) -> tensor<4x512xi32>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<4x1000xi8>, tensor<1000x512xi8>) outs(%acc: tensor<4x512xi32>) -> tensor<4x512xi32>
+  return %result: tensor<4x512xi32>
+}
+
+func.func @matmul_512x1000xi8_times_1000x4xi8_into_512x4xi32(%lhs: tensor<512x1000xi8>, %rhs: tensor<1000x4xi8>) -> tensor<512x4xi32> {
+  %init_acc = tensor.empty() : tensor<512x4xi32>
+  %c0_acc_type = arith.constant 0: i32
+  %acc = linalg.fill ins(%c0_acc_type : i32) outs(%init_acc : tensor<512x4xi32>) -> tensor<512x4xi32>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<512x1000xi8>, tensor<1000x4xi8>) outs(%acc: tensor<512x4xi32>) -> tensor<512x4xi32>
+  return %result: tensor<512x4xi32>
+}
+
+func.func @matmul_512x128xi8_times_128x500xi8_into_512x500xi32(%lhs: tensor<512x128xi8>, %rhs: tensor<128x500xi8>) -> tensor<512x500xi32> {
+  %init_acc = tensor.empty() : tensor<512x500xi32>
+  %c0_acc_type = arith.constant 0: i32
+  %acc = linalg.fill ins(%c0_acc_type : i32) outs(%init_acc : tensor<512x500xi32>) -> tensor<512x500xi32>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<512x128xi8>, tensor<128x500xi8>) outs(%acc: tensor<512x500xi32>) -> tensor<512x500xi32>
+  return %result: tensor<512x500xi32>
+}
+
+func.func @matmul_457x160xi8_times_160x512xi8_into_457x512xi32(%lhs: tensor<457x160xi8>, %rhs: tensor<160x512xi8>) -> tensor<457x512xi32> {
+  %init_acc = tensor.empty() : tensor<457x512xi32>
+  %c0_acc_type = arith.constant 0: i32
+  %acc = linalg.fill ins(%c0_acc_type : i32) outs(%init_acc : tensor<457x512xi32>) -> tensor<457x512xi32>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<457x160xi8>, tensor<160x512xi8>) outs(%acc: tensor<457x512xi32>) -> tensor<457x512xi32>
+  return %result: tensor<457x512xi32>
+}
+
+func.func @matmul_512x330xi8_times_330x512xi8_into_512x512xi32(%lhs: tensor<512x330xi8>, %rhs: tensor<330x512xi8>) -> tensor<512x512xi32> {
+  %init_acc = tensor.empty() : tensor<512x512xi32>
+  %c0_acc_type = arith.constant 0: i32
+  %acc = linalg.fill ins(%c0_acc_type : i32) outs(%init_acc : tensor<512x512xi32>) -> tensor<512x512xi32>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<512x330xi8>, tensor<330x512xi8>) outs(%acc: tensor<512x512xi32>) -> tensor<512x512xi32>
+  return %result: tensor<512x512xi32>
+}
+

--- a/matmul/tests/generated/matmul_i8_i32_large_calls.mlir
+++ b/matmul/tests/generated/matmul_i8_i32_large_calls.mlir
@@ -1,0 +1,321 @@
+builtin.module @calls attributes {
+  
+} {
+
+func.func private @matmul_test.generate_random_matrix(%device: !hal.device, %dim0: i64, %dim1: i64, %element_type: i32, %seed: i32) -> !hal.buffer_view
+func.func private @matmul_test.check_matmul_results(%device: !hal.device, %m: i64, %k: i64, %n: i64, %transpose_rhs: i32, %lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view, %actual_result: !hal.buffer_view)
+
+func.func private @module.matmul_accumulate_DYNxDYNxi8_times_DYNxDYNxi8_into_DYNxDYNxi32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_123x456xi8_times_456x789xi8_into_123x789xi32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_DYNxDYNxi8_times_DYNxDYNxi8_into_DYNxDYNxi32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_654x321xi8_times_321x234xi8_into_654x234xi32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_1x1000xi8_times_1000x1000xi8_into_1x1000xi32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_1000x1000xi8_times_1000x1xi8_into_1000x1xi32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_1000x1000xi8_times_1000x1xi8_into_1000x1xi32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+
+func.func @matmul_accumulate_DYNxDYNxi8_times_DYNxDYNxi8_into_DYNxDYNxi32_123_456_789_acc_0() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 123x456x789"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 123 : i64
+  %lhs_dim1 = arith.constant 456 : i64
+  %lhs_element_type = hal.element_type<i8> : i32
+  %lhs_seed = arith.constant 2 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 456 : i64
+  %rhs_dim1 = arith.constant 789 : i64
+  %rhs_element_type = hal.element_type<i8> : i32
+  %rhs_seed = arith.constant 3 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 123 : i64
+  %acc_dim1 = arith.constant 789 : i64
+  %acc_element_type = hal.element_type<i32> : i32
+  %acc_seed = arith.constant 4 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 123 : i64
+  %acc_copy_dim1 = arith.constant 789 : i64
+  %acc_copy_element_type = hal.element_type<i32> : i32
+  %acc_copy_seed = arith.constant 4 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxi8_times_DYNxDYNxi8_into_DYNxDYNxi32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 123 : i64
+  %k = arith.constant 456 : i64
+  %n = arith.constant 789 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_123x456xi8_times_456x789xi8_into_123x789xi32_123_456_789_acc_1() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 123x456x789"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 123 : i64
+  %lhs_dim1 = arith.constant 456 : i64
+  %lhs_element_type = hal.element_type<i8> : i32
+  %lhs_seed = arith.constant 5 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 456 : i64
+  %rhs_dim1 = arith.constant 789 : i64
+  %rhs_element_type = hal.element_type<i8> : i32
+  %rhs_seed = arith.constant 6 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 123 : i64
+  %acc_dim1 = arith.constant 789 : i64
+  %acc_element_type = hal.element_type<i32> : i32
+  %acc_seed = arith.constant 7 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 123 : i64
+  %acc_copy_dim1 = arith.constant 789 : i64
+  %acc_copy_element_type = hal.element_type<i32> : i32
+  %acc_copy_seed = arith.constant 7 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_123x456xi8_times_456x789xi8_into_123x789xi32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 123 : i64
+  %k = arith.constant 456 : i64
+  %n = arith.constant 789 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_DYNxDYNxi8_times_DYNxDYNxi8_into_DYNxDYNxi32_654_321_234_2() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 654x321x234"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 654 : i64
+  %lhs_dim1 = arith.constant 321 : i64
+  %lhs_element_type = hal.element_type<i8> : i32
+  %lhs_seed = arith.constant 8 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 321 : i64
+  %rhs_dim1 = arith.constant 234 : i64
+  %rhs_element_type = hal.element_type<i8> : i32
+  %rhs_seed = arith.constant 9 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_DYNxDYNxi8_times_DYNxDYNxi8_into_DYNxDYNxi32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 654 : i64
+  %k = arith.constant 321 : i64
+  %n = arith.constant 234 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_654x321xi8_times_321x234xi8_into_654x234xi32_654_321_234_3() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 654x321x234"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 654 : i64
+  %lhs_dim1 = arith.constant 321 : i64
+  %lhs_element_type = hal.element_type<i8> : i32
+  %lhs_seed = arith.constant 10 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 321 : i64
+  %rhs_dim1 = arith.constant 234 : i64
+  %rhs_element_type = hal.element_type<i8> : i32
+  %rhs_seed = arith.constant 11 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_654x321xi8_times_321x234xi8_into_654x234xi32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 654 : i64
+  %k = arith.constant 321 : i64
+  %n = arith.constant 234 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_DYNxDYNxi8_times_DYNxDYNxi8_into_DYNxDYNxi32_1_1000_1000_acc_4() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1x1000x1000"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1 : i64
+  %lhs_dim1 = arith.constant 1000 : i64
+  %lhs_element_type = hal.element_type<i8> : i32
+  %lhs_seed = arith.constant 12 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1000 : i64
+  %rhs_dim1 = arith.constant 1000 : i64
+  %rhs_element_type = hal.element_type<i8> : i32
+  %rhs_seed = arith.constant 13 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 1 : i64
+  %acc_dim1 = arith.constant 1000 : i64
+  %acc_element_type = hal.element_type<i32> : i32
+  %acc_seed = arith.constant 14 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 1 : i64
+  %acc_copy_dim1 = arith.constant 1000 : i64
+  %acc_copy_element_type = hal.element_type<i32> : i32
+  %acc_copy_seed = arith.constant 14 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxi8_times_DYNxDYNxi8_into_DYNxDYNxi32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1 : i64
+  %k = arith.constant 1000 : i64
+  %n = arith.constant 1000 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_1x1000xi8_times_1000x1000xi8_into_1x1000xi32_1_1000_1000_acc_5() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1x1000x1000"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1 : i64
+  %lhs_dim1 = arith.constant 1000 : i64
+  %lhs_element_type = hal.element_type<i8> : i32
+  %lhs_seed = arith.constant 15 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1000 : i64
+  %rhs_dim1 = arith.constant 1000 : i64
+  %rhs_element_type = hal.element_type<i8> : i32
+  %rhs_seed = arith.constant 16 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 1 : i64
+  %acc_dim1 = arith.constant 1000 : i64
+  %acc_element_type = hal.element_type<i32> : i32
+  %acc_seed = arith.constant 17 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 1 : i64
+  %acc_copy_dim1 = arith.constant 1000 : i64
+  %acc_copy_element_type = hal.element_type<i32> : i32
+  %acc_copy_seed = arith.constant 17 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_1x1000xi8_times_1000x1000xi8_into_1x1000xi32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1 : i64
+  %k = arith.constant 1000 : i64
+  %n = arith.constant 1000 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_DYNxDYNxi8_times_DYNxDYNxi8_into_DYNxDYNxi32_1000_1000_1_acc_6() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1000x1000x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1000 : i64
+  %lhs_dim1 = arith.constant 1000 : i64
+  %lhs_element_type = hal.element_type<i8> : i32
+  %lhs_seed = arith.constant 18 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1000 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<i8> : i32
+  %rhs_seed = arith.constant 19 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 1000 : i64
+  %acc_dim1 = arith.constant 1 : i64
+  %acc_element_type = hal.element_type<i32> : i32
+  %acc_seed = arith.constant 20 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 1000 : i64
+  %acc_copy_dim1 = arith.constant 1 : i64
+  %acc_copy_element_type = hal.element_type<i32> : i32
+  %acc_copy_seed = arith.constant 20 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxi8_times_DYNxDYNxi8_into_DYNxDYNxi32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1000 : i64
+  %k = arith.constant 1000 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_1000x1000xi8_times_1000x1xi8_into_1000x1xi32_1000_1000_1_acc_7() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1000x1000x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1000 : i64
+  %lhs_dim1 = arith.constant 1000 : i64
+  %lhs_element_type = hal.element_type<i8> : i32
+  %lhs_seed = arith.constant 21 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1000 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<i8> : i32
+  %rhs_seed = arith.constant 22 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 1000 : i64
+  %acc_dim1 = arith.constant 1 : i64
+  %acc_element_type = hal.element_type<i32> : i32
+  %acc_seed = arith.constant 23 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 1000 : i64
+  %acc_copy_dim1 = arith.constant 1 : i64
+  %acc_copy_element_type = hal.element_type<i32> : i32
+  %acc_copy_seed = arith.constant 23 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_1000x1000xi8_times_1000x1xi8_into_1000x1xi32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1000 : i64
+  %k = arith.constant 1000 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_DYNxDYNxi8_times_DYNxDYNxi8_into_DYNxDYNxi32_1000_1000_1_8() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1000x1000x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1000 : i64
+  %lhs_dim1 = arith.constant 1000 : i64
+  %lhs_element_type = hal.element_type<i8> : i32
+  %lhs_seed = arith.constant 24 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1000 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<i8> : i32
+  %rhs_seed = arith.constant 25 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_DYNxDYNxi8_times_DYNxDYNxi8_into_DYNxDYNxi32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1000 : i64
+  %k = arith.constant 1000 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_1000x1000xi8_times_1000x1xi8_into_1000x1xi32_1000_1000_1_9() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1000x1000x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1000 : i64
+  %lhs_dim1 = arith.constant 1000 : i64
+  %lhs_element_type = hal.element_type<i8> : i32
+  %lhs_seed = arith.constant 26 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1000 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<i8> : i32
+  %rhs_seed = arith.constant 27 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_1000x1000xi8_times_1000x1xi8_into_1000x1xi32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1000 : i64
+  %k = arith.constant 1000 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+
+}

--- a/matmul/tests/generated/matmul_i8_i32_large_matmul.mlir
+++ b/matmul/tests/generated/matmul_i8_i32_large_matmul.mlir
@@ -1,0 +1,48 @@
+func.func @matmul_accumulate_DYNxDYNxi8_times_DYNxDYNxi8_into_DYNxDYNxi32(%lhs: tensor<?x?xi8>, %rhs: tensor<?x?xi8>, %acc: tensor<?x?xi32>) -> tensor<?x?xi32> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<?x?xi8>, tensor<?x?xi8>) outs(%acc: tensor<?x?xi32>) -> tensor<?x?xi32>
+  return %result: tensor<?x?xi32>
+}
+
+func.func @matmul_accumulate_123x456xi8_times_456x789xi8_into_123x789xi32(%lhs: tensor<123x456xi8>, %rhs: tensor<456x789xi8>, %acc: tensor<123x789xi32>) -> tensor<123x789xi32> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<123x456xi8>, tensor<456x789xi8>) outs(%acc: tensor<123x789xi32>) -> tensor<123x789xi32>
+  return %result: tensor<123x789xi32>
+}
+
+func.func @matmul_DYNxDYNxi8_times_DYNxDYNxi8_into_DYNxDYNxi32(%lhs: tensor<?x?xi8>, %rhs: tensor<?x?xi8>) -> tensor<?x?xi32> {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %acc_dim0 = tensor.dim %lhs, %c0 : tensor<?x?xi8>
+  %acc_dim1 = tensor.dim %rhs, %c1 : tensor<?x?xi8>
+  %init_acc = tensor.empty(%acc_dim0, %acc_dim1) : tensor<?x?xi32>
+  %c0_acc_type = arith.constant 0: i32
+  %acc = linalg.fill ins(%c0_acc_type : i32) outs(%init_acc : tensor<?x?xi32>) -> tensor<?x?xi32>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<?x?xi8>, tensor<?x?xi8>) outs(%acc: tensor<?x?xi32>) -> tensor<?x?xi32>
+  return %result: tensor<?x?xi32>
+}
+
+func.func @matmul_654x321xi8_times_321x234xi8_into_654x234xi32(%lhs: tensor<654x321xi8>, %rhs: tensor<321x234xi8>) -> tensor<654x234xi32> {
+  %init_acc = tensor.empty() : tensor<654x234xi32>
+  %c0_acc_type = arith.constant 0: i32
+  %acc = linalg.fill ins(%c0_acc_type : i32) outs(%init_acc : tensor<654x234xi32>) -> tensor<654x234xi32>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<654x321xi8>, tensor<321x234xi8>) outs(%acc: tensor<654x234xi32>) -> tensor<654x234xi32>
+  return %result: tensor<654x234xi32>
+}
+
+func.func @matmul_accumulate_1x1000xi8_times_1000x1000xi8_into_1x1000xi32(%lhs: tensor<1x1000xi8>, %rhs: tensor<1000x1000xi8>, %acc: tensor<1x1000xi32>) -> tensor<1x1000xi32> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<1x1000xi8>, tensor<1000x1000xi8>) outs(%acc: tensor<1x1000xi32>) -> tensor<1x1000xi32>
+  return %result: tensor<1x1000xi32>
+}
+
+func.func @matmul_accumulate_1000x1000xi8_times_1000x1xi8_into_1000x1xi32(%lhs: tensor<1000x1000xi8>, %rhs: tensor<1000x1xi8>, %acc: tensor<1000x1xi32>) -> tensor<1000x1xi32> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<1000x1000xi8>, tensor<1000x1xi8>) outs(%acc: tensor<1000x1xi32>) -> tensor<1000x1xi32>
+  return %result: tensor<1000x1xi32>
+}
+
+func.func @matmul_1000x1000xi8_times_1000x1xi8_into_1000x1xi32(%lhs: tensor<1000x1000xi8>, %rhs: tensor<1000x1xi8>) -> tensor<1000x1xi32> {
+  %init_acc = tensor.empty() : tensor<1000x1xi32>
+  %c0_acc_type = arith.constant 0: i32
+  %acc = linalg.fill ins(%c0_acc_type : i32) outs(%init_acc : tensor<1000x1xi32>) -> tensor<1000x1xi32>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<1000x1000xi8>, tensor<1000x1xi8>) outs(%acc: tensor<1000x1xi32>) -> tensor<1000x1xi32>
+  return %result: tensor<1000x1xi32>
+}
+

--- a/matmul/tests/generated/matmul_i8_i32_small_calls.mlir
+++ b/matmul/tests/generated/matmul_i8_i32_small_calls.mlir
@@ -1,0 +1,906 @@
+builtin.module @calls attributes {
+  
+} {
+
+func.func private @matmul_test.generate_random_matrix(%device: !hal.device, %dim0: i64, %dim1: i64, %element_type: i32, %seed: i32) -> !hal.buffer_view
+func.func private @matmul_test.check_matmul_results(%device: !hal.device, %m: i64, %k: i64, %n: i64, %transpose_rhs: i32, %lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view, %actual_result: !hal.buffer_view)
+
+func.func private @module.matmul_accumulate_DYNxDYNxi8_times_DYNxDYNxi8_into_DYNxDYNxi32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_1x1xi8_times_1x1xi8_into_1x1xi32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_DYNxDYNxi8_times_DYNxDYNxi8_into_DYNxDYNxi32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_1x1xi8_times_1x1xi8_into_1x1xi32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_2x2xi8_times_2x2xi8_into_2x2xi32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_4x4xi8_times_4x4xi8_into_4x4xi32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_8x8xi8_times_8x8xi8_into_8x8xi32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_9x9xi8_times_9x9xi8_into_9x9xi32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_6x13xi8_times_13x3xi8_into_6x3xi32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_15x37xi8_times_37x7xi8_into_15x7xi32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_81x19xi8_times_19x41xi8_into_81x41xi32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_1x10xi8_times_10x10xi8_into_1x10xi32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_1x10xi8_times_10x10xi8_into_1x10xi32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_10x1xi8_times_1x10xi8_into_10x10xi32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_accumulate_10x10xi8_times_10x1xi8_into_10x1xi32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view, %acc: !hal.buffer_view) -> !hal.buffer_view
+func.func private @module.matmul_10x10xi8_times_10x1xi8_into_10x1xi32(%lhs: !hal.buffer_view, %rhs: !hal.buffer_view) -> !hal.buffer_view
+
+func.func @matmul_accumulate_DYNxDYNxi8_times_DYNxDYNxi8_into_DYNxDYNxi32_1_1_1_acc_0() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1x1x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1 : i64
+  %lhs_dim1 = arith.constant 1 : i64
+  %lhs_element_type = hal.element_type<i8> : i32
+  %lhs_seed = arith.constant 2 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<i8> : i32
+  %rhs_seed = arith.constant 3 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 1 : i64
+  %acc_dim1 = arith.constant 1 : i64
+  %acc_element_type = hal.element_type<i32> : i32
+  %acc_seed = arith.constant 4 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 1 : i64
+  %acc_copy_dim1 = arith.constant 1 : i64
+  %acc_copy_element_type = hal.element_type<i32> : i32
+  %acc_copy_seed = arith.constant 4 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxi8_times_DYNxDYNxi8_into_DYNxDYNxi32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1 : i64
+  %k = arith.constant 1 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_1x1xi8_times_1x1xi8_into_1x1xi32_1_1_1_acc_1() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1x1x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1 : i64
+  %lhs_dim1 = arith.constant 1 : i64
+  %lhs_element_type = hal.element_type<i8> : i32
+  %lhs_seed = arith.constant 5 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<i8> : i32
+  %rhs_seed = arith.constant 6 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 1 : i64
+  %acc_dim1 = arith.constant 1 : i64
+  %acc_element_type = hal.element_type<i32> : i32
+  %acc_seed = arith.constant 7 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 1 : i64
+  %acc_copy_dim1 = arith.constant 1 : i64
+  %acc_copy_element_type = hal.element_type<i32> : i32
+  %acc_copy_seed = arith.constant 7 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_1x1xi8_times_1x1xi8_into_1x1xi32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1 : i64
+  %k = arith.constant 1 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_DYNxDYNxi8_times_DYNxDYNxi8_into_DYNxDYNxi32_1_1_1_2() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1x1x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1 : i64
+  %lhs_dim1 = arith.constant 1 : i64
+  %lhs_element_type = hal.element_type<i8> : i32
+  %lhs_seed = arith.constant 8 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<i8> : i32
+  %rhs_seed = arith.constant 9 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_DYNxDYNxi8_times_DYNxDYNxi8_into_DYNxDYNxi32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1 : i64
+  %k = arith.constant 1 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_1x1xi8_times_1x1xi8_into_1x1xi32_1_1_1_3() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1x1x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1 : i64
+  %lhs_dim1 = arith.constant 1 : i64
+  %lhs_element_type = hal.element_type<i8> : i32
+  %lhs_seed = arith.constant 10 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<i8> : i32
+  %rhs_seed = arith.constant 11 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_1x1xi8_times_1x1xi8_into_1x1xi32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1 : i64
+  %k = arith.constant 1 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_DYNxDYNxi8_times_DYNxDYNxi8_into_DYNxDYNxi32_2_2_2_acc_4() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 2x2x2"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 2 : i64
+  %lhs_dim1 = arith.constant 2 : i64
+  %lhs_element_type = hal.element_type<i8> : i32
+  %lhs_seed = arith.constant 12 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 2 : i64
+  %rhs_dim1 = arith.constant 2 : i64
+  %rhs_element_type = hal.element_type<i8> : i32
+  %rhs_seed = arith.constant 13 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 2 : i64
+  %acc_dim1 = arith.constant 2 : i64
+  %acc_element_type = hal.element_type<i32> : i32
+  %acc_seed = arith.constant 14 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 2 : i64
+  %acc_copy_dim1 = arith.constant 2 : i64
+  %acc_copy_element_type = hal.element_type<i32> : i32
+  %acc_copy_seed = arith.constant 14 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxi8_times_DYNxDYNxi8_into_DYNxDYNxi32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 2 : i64
+  %k = arith.constant 2 : i64
+  %n = arith.constant 2 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_2x2xi8_times_2x2xi8_into_2x2xi32_2_2_2_acc_5() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 2x2x2"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 2 : i64
+  %lhs_dim1 = arith.constant 2 : i64
+  %lhs_element_type = hal.element_type<i8> : i32
+  %lhs_seed = arith.constant 15 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 2 : i64
+  %rhs_dim1 = arith.constant 2 : i64
+  %rhs_element_type = hal.element_type<i8> : i32
+  %rhs_seed = arith.constant 16 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 2 : i64
+  %acc_dim1 = arith.constant 2 : i64
+  %acc_element_type = hal.element_type<i32> : i32
+  %acc_seed = arith.constant 17 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 2 : i64
+  %acc_copy_dim1 = arith.constant 2 : i64
+  %acc_copy_element_type = hal.element_type<i32> : i32
+  %acc_copy_seed = arith.constant 17 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_2x2xi8_times_2x2xi8_into_2x2xi32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 2 : i64
+  %k = arith.constant 2 : i64
+  %n = arith.constant 2 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_DYNxDYNxi8_times_DYNxDYNxi8_into_DYNxDYNxi32_4_4_4_acc_6() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 4x4x4"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 4 : i64
+  %lhs_dim1 = arith.constant 4 : i64
+  %lhs_element_type = hal.element_type<i8> : i32
+  %lhs_seed = arith.constant 18 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 4 : i64
+  %rhs_dim1 = arith.constant 4 : i64
+  %rhs_element_type = hal.element_type<i8> : i32
+  %rhs_seed = arith.constant 19 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 4 : i64
+  %acc_dim1 = arith.constant 4 : i64
+  %acc_element_type = hal.element_type<i32> : i32
+  %acc_seed = arith.constant 20 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 4 : i64
+  %acc_copy_dim1 = arith.constant 4 : i64
+  %acc_copy_element_type = hal.element_type<i32> : i32
+  %acc_copy_seed = arith.constant 20 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxi8_times_DYNxDYNxi8_into_DYNxDYNxi32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 4 : i64
+  %k = arith.constant 4 : i64
+  %n = arith.constant 4 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_4x4xi8_times_4x4xi8_into_4x4xi32_4_4_4_acc_7() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 4x4x4"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 4 : i64
+  %lhs_dim1 = arith.constant 4 : i64
+  %lhs_element_type = hal.element_type<i8> : i32
+  %lhs_seed = arith.constant 21 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 4 : i64
+  %rhs_dim1 = arith.constant 4 : i64
+  %rhs_element_type = hal.element_type<i8> : i32
+  %rhs_seed = arith.constant 22 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 4 : i64
+  %acc_dim1 = arith.constant 4 : i64
+  %acc_element_type = hal.element_type<i32> : i32
+  %acc_seed = arith.constant 23 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 4 : i64
+  %acc_copy_dim1 = arith.constant 4 : i64
+  %acc_copy_element_type = hal.element_type<i32> : i32
+  %acc_copy_seed = arith.constant 23 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_4x4xi8_times_4x4xi8_into_4x4xi32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 4 : i64
+  %k = arith.constant 4 : i64
+  %n = arith.constant 4 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_DYNxDYNxi8_times_DYNxDYNxi8_into_DYNxDYNxi32_8_8_8_acc_8() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 8x8x8"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 8 : i64
+  %lhs_dim1 = arith.constant 8 : i64
+  %lhs_element_type = hal.element_type<i8> : i32
+  %lhs_seed = arith.constant 24 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 8 : i64
+  %rhs_dim1 = arith.constant 8 : i64
+  %rhs_element_type = hal.element_type<i8> : i32
+  %rhs_seed = arith.constant 25 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 8 : i64
+  %acc_dim1 = arith.constant 8 : i64
+  %acc_element_type = hal.element_type<i32> : i32
+  %acc_seed = arith.constant 26 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 8 : i64
+  %acc_copy_dim1 = arith.constant 8 : i64
+  %acc_copy_element_type = hal.element_type<i32> : i32
+  %acc_copy_seed = arith.constant 26 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxi8_times_DYNxDYNxi8_into_DYNxDYNxi32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 8 : i64
+  %k = arith.constant 8 : i64
+  %n = arith.constant 8 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_8x8xi8_times_8x8xi8_into_8x8xi32_8_8_8_acc_9() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 8x8x8"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 8 : i64
+  %lhs_dim1 = arith.constant 8 : i64
+  %lhs_element_type = hal.element_type<i8> : i32
+  %lhs_seed = arith.constant 27 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 8 : i64
+  %rhs_dim1 = arith.constant 8 : i64
+  %rhs_element_type = hal.element_type<i8> : i32
+  %rhs_seed = arith.constant 28 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 8 : i64
+  %acc_dim1 = arith.constant 8 : i64
+  %acc_element_type = hal.element_type<i32> : i32
+  %acc_seed = arith.constant 29 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 8 : i64
+  %acc_copy_dim1 = arith.constant 8 : i64
+  %acc_copy_element_type = hal.element_type<i32> : i32
+  %acc_copy_seed = arith.constant 29 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_8x8xi8_times_8x8xi8_into_8x8xi32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 8 : i64
+  %k = arith.constant 8 : i64
+  %n = arith.constant 8 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_DYNxDYNxi8_times_DYNxDYNxi8_into_DYNxDYNxi32_9_9_9_acc_10() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 9x9x9"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 9 : i64
+  %lhs_dim1 = arith.constant 9 : i64
+  %lhs_element_type = hal.element_type<i8> : i32
+  %lhs_seed = arith.constant 30 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 9 : i64
+  %rhs_dim1 = arith.constant 9 : i64
+  %rhs_element_type = hal.element_type<i8> : i32
+  %rhs_seed = arith.constant 31 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 9 : i64
+  %acc_dim1 = arith.constant 9 : i64
+  %acc_element_type = hal.element_type<i32> : i32
+  %acc_seed = arith.constant 32 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 9 : i64
+  %acc_copy_dim1 = arith.constant 9 : i64
+  %acc_copy_element_type = hal.element_type<i32> : i32
+  %acc_copy_seed = arith.constant 32 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxi8_times_DYNxDYNxi8_into_DYNxDYNxi32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 9 : i64
+  %k = arith.constant 9 : i64
+  %n = arith.constant 9 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_9x9xi8_times_9x9xi8_into_9x9xi32_9_9_9_acc_11() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 9x9x9"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 9 : i64
+  %lhs_dim1 = arith.constant 9 : i64
+  %lhs_element_type = hal.element_type<i8> : i32
+  %lhs_seed = arith.constant 33 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 9 : i64
+  %rhs_dim1 = arith.constant 9 : i64
+  %rhs_element_type = hal.element_type<i8> : i32
+  %rhs_seed = arith.constant 34 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 9 : i64
+  %acc_dim1 = arith.constant 9 : i64
+  %acc_element_type = hal.element_type<i32> : i32
+  %acc_seed = arith.constant 35 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 9 : i64
+  %acc_copy_dim1 = arith.constant 9 : i64
+  %acc_copy_element_type = hal.element_type<i32> : i32
+  %acc_copy_seed = arith.constant 35 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_9x9xi8_times_9x9xi8_into_9x9xi32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 9 : i64
+  %k = arith.constant 9 : i64
+  %n = arith.constant 9 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_DYNxDYNxi8_times_DYNxDYNxi8_into_DYNxDYNxi32_6_13_3_acc_12() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 6x13x3"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 6 : i64
+  %lhs_dim1 = arith.constant 13 : i64
+  %lhs_element_type = hal.element_type<i8> : i32
+  %lhs_seed = arith.constant 36 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 13 : i64
+  %rhs_dim1 = arith.constant 3 : i64
+  %rhs_element_type = hal.element_type<i8> : i32
+  %rhs_seed = arith.constant 37 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 6 : i64
+  %acc_dim1 = arith.constant 3 : i64
+  %acc_element_type = hal.element_type<i32> : i32
+  %acc_seed = arith.constant 38 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 6 : i64
+  %acc_copy_dim1 = arith.constant 3 : i64
+  %acc_copy_element_type = hal.element_type<i32> : i32
+  %acc_copy_seed = arith.constant 38 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxi8_times_DYNxDYNxi8_into_DYNxDYNxi32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 6 : i64
+  %k = arith.constant 13 : i64
+  %n = arith.constant 3 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_6x13xi8_times_13x3xi8_into_6x3xi32_6_13_3_acc_13() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 6x13x3"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 6 : i64
+  %lhs_dim1 = arith.constant 13 : i64
+  %lhs_element_type = hal.element_type<i8> : i32
+  %lhs_seed = arith.constant 39 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 13 : i64
+  %rhs_dim1 = arith.constant 3 : i64
+  %rhs_element_type = hal.element_type<i8> : i32
+  %rhs_seed = arith.constant 40 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 6 : i64
+  %acc_dim1 = arith.constant 3 : i64
+  %acc_element_type = hal.element_type<i32> : i32
+  %acc_seed = arith.constant 41 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 6 : i64
+  %acc_copy_dim1 = arith.constant 3 : i64
+  %acc_copy_element_type = hal.element_type<i32> : i32
+  %acc_copy_seed = arith.constant 41 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_6x13xi8_times_13x3xi8_into_6x3xi32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 6 : i64
+  %k = arith.constant 13 : i64
+  %n = arith.constant 3 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_DYNxDYNxi8_times_DYNxDYNxi8_into_DYNxDYNxi32_15_37_7_14() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 15x37x7"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 15 : i64
+  %lhs_dim1 = arith.constant 37 : i64
+  %lhs_element_type = hal.element_type<i8> : i32
+  %lhs_seed = arith.constant 42 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 37 : i64
+  %rhs_dim1 = arith.constant 7 : i64
+  %rhs_element_type = hal.element_type<i8> : i32
+  %rhs_seed = arith.constant 43 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_DYNxDYNxi8_times_DYNxDYNxi8_into_DYNxDYNxi32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 15 : i64
+  %k = arith.constant 37 : i64
+  %n = arith.constant 7 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_15x37xi8_times_37x7xi8_into_15x7xi32_15_37_7_15() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 15x37x7"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 15 : i64
+  %lhs_dim1 = arith.constant 37 : i64
+  %lhs_element_type = hal.element_type<i8> : i32
+  %lhs_seed = arith.constant 44 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 37 : i64
+  %rhs_dim1 = arith.constant 7 : i64
+  %rhs_element_type = hal.element_type<i8> : i32
+  %rhs_seed = arith.constant 45 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_15x37xi8_times_37x7xi8_into_15x7xi32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 15 : i64
+  %k = arith.constant 37 : i64
+  %n = arith.constant 7 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_DYNxDYNxi8_times_DYNxDYNxi8_into_DYNxDYNxi32_81_19_41_acc_16() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 81x19x41"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 81 : i64
+  %lhs_dim1 = arith.constant 19 : i64
+  %lhs_element_type = hal.element_type<i8> : i32
+  %lhs_seed = arith.constant 46 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 19 : i64
+  %rhs_dim1 = arith.constant 41 : i64
+  %rhs_element_type = hal.element_type<i8> : i32
+  %rhs_seed = arith.constant 47 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 81 : i64
+  %acc_dim1 = arith.constant 41 : i64
+  %acc_element_type = hal.element_type<i32> : i32
+  %acc_seed = arith.constant 48 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 81 : i64
+  %acc_copy_dim1 = arith.constant 41 : i64
+  %acc_copy_element_type = hal.element_type<i32> : i32
+  %acc_copy_seed = arith.constant 48 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxi8_times_DYNxDYNxi8_into_DYNxDYNxi32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 81 : i64
+  %k = arith.constant 19 : i64
+  %n = arith.constant 41 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_81x19xi8_times_19x41xi8_into_81x41xi32_81_19_41_acc_17() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 81x19x41"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 81 : i64
+  %lhs_dim1 = arith.constant 19 : i64
+  %lhs_element_type = hal.element_type<i8> : i32
+  %lhs_seed = arith.constant 49 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 19 : i64
+  %rhs_dim1 = arith.constant 41 : i64
+  %rhs_element_type = hal.element_type<i8> : i32
+  %rhs_seed = arith.constant 50 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 81 : i64
+  %acc_dim1 = arith.constant 41 : i64
+  %acc_element_type = hal.element_type<i32> : i32
+  %acc_seed = arith.constant 51 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 81 : i64
+  %acc_copy_dim1 = arith.constant 41 : i64
+  %acc_copy_element_type = hal.element_type<i32> : i32
+  %acc_copy_seed = arith.constant 51 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_81x19xi8_times_19x41xi8_into_81x41xi32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 81 : i64
+  %k = arith.constant 19 : i64
+  %n = arith.constant 41 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_DYNxDYNxi8_times_DYNxDYNxi8_into_DYNxDYNxi32_1_10_10_acc_18() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1x10x10"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1 : i64
+  %lhs_dim1 = arith.constant 10 : i64
+  %lhs_element_type = hal.element_type<i8> : i32
+  %lhs_seed = arith.constant 52 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 10 : i64
+  %rhs_dim1 = arith.constant 10 : i64
+  %rhs_element_type = hal.element_type<i8> : i32
+  %rhs_seed = arith.constant 53 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 1 : i64
+  %acc_dim1 = arith.constant 10 : i64
+  %acc_element_type = hal.element_type<i32> : i32
+  %acc_seed = arith.constant 54 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 1 : i64
+  %acc_copy_dim1 = arith.constant 10 : i64
+  %acc_copy_element_type = hal.element_type<i32> : i32
+  %acc_copy_seed = arith.constant 54 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxi8_times_DYNxDYNxi8_into_DYNxDYNxi32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1 : i64
+  %k = arith.constant 10 : i64
+  %n = arith.constant 10 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_1x10xi8_times_10x10xi8_into_1x10xi32_1_10_10_acc_19() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1x10x10"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1 : i64
+  %lhs_dim1 = arith.constant 10 : i64
+  %lhs_element_type = hal.element_type<i8> : i32
+  %lhs_seed = arith.constant 55 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 10 : i64
+  %rhs_dim1 = arith.constant 10 : i64
+  %rhs_element_type = hal.element_type<i8> : i32
+  %rhs_seed = arith.constant 56 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 1 : i64
+  %acc_dim1 = arith.constant 10 : i64
+  %acc_element_type = hal.element_type<i32> : i32
+  %acc_seed = arith.constant 57 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 1 : i64
+  %acc_copy_dim1 = arith.constant 10 : i64
+  %acc_copy_element_type = hal.element_type<i32> : i32
+  %acc_copy_seed = arith.constant 57 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_1x10xi8_times_10x10xi8_into_1x10xi32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1 : i64
+  %k = arith.constant 10 : i64
+  %n = arith.constant 10 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_DYNxDYNxi8_times_DYNxDYNxi8_into_DYNxDYNxi32_1_10_10_20() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1x10x10"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1 : i64
+  %lhs_dim1 = arith.constant 10 : i64
+  %lhs_element_type = hal.element_type<i8> : i32
+  %lhs_seed = arith.constant 58 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 10 : i64
+  %rhs_dim1 = arith.constant 10 : i64
+  %rhs_element_type = hal.element_type<i8> : i32
+  %rhs_seed = arith.constant 59 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_DYNxDYNxi8_times_DYNxDYNxi8_into_DYNxDYNxi32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1 : i64
+  %k = arith.constant 10 : i64
+  %n = arith.constant 10 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_1x10xi8_times_10x10xi8_into_1x10xi32_1_10_10_21() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 1x10x10"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 1 : i64
+  %lhs_dim1 = arith.constant 10 : i64
+  %lhs_element_type = hal.element_type<i8> : i32
+  %lhs_seed = arith.constant 60 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 10 : i64
+  %rhs_dim1 = arith.constant 10 : i64
+  %rhs_element_type = hal.element_type<i8> : i32
+  %rhs_seed = arith.constant 61 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_1x10xi8_times_10x10xi8_into_1x10xi32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 1 : i64
+  %k = arith.constant 10 : i64
+  %n = arith.constant 10 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_DYNxDYNxi8_times_DYNxDYNxi8_into_DYNxDYNxi32_10_1_10_acc_22() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 10x1x10"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 10 : i64
+  %lhs_dim1 = arith.constant 1 : i64
+  %lhs_element_type = hal.element_type<i8> : i32
+  %lhs_seed = arith.constant 62 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1 : i64
+  %rhs_dim1 = arith.constant 10 : i64
+  %rhs_element_type = hal.element_type<i8> : i32
+  %rhs_seed = arith.constant 63 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 10 : i64
+  %acc_dim1 = arith.constant 10 : i64
+  %acc_element_type = hal.element_type<i32> : i32
+  %acc_seed = arith.constant 64 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 10 : i64
+  %acc_copy_dim1 = arith.constant 10 : i64
+  %acc_copy_element_type = hal.element_type<i32> : i32
+  %acc_copy_seed = arith.constant 64 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxi8_times_DYNxDYNxi8_into_DYNxDYNxi32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 10 : i64
+  %k = arith.constant 1 : i64
+  %n = arith.constant 10 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_10x1xi8_times_1x10xi8_into_10x10xi32_10_1_10_acc_23() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 10x1x10"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 10 : i64
+  %lhs_dim1 = arith.constant 1 : i64
+  %lhs_element_type = hal.element_type<i8> : i32
+  %lhs_seed = arith.constant 65 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 1 : i64
+  %rhs_dim1 = arith.constant 10 : i64
+  %rhs_element_type = hal.element_type<i8> : i32
+  %rhs_seed = arith.constant 66 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 10 : i64
+  %acc_dim1 = arith.constant 10 : i64
+  %acc_element_type = hal.element_type<i32> : i32
+  %acc_seed = arith.constant 67 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 10 : i64
+  %acc_copy_dim1 = arith.constant 10 : i64
+  %acc_copy_element_type = hal.element_type<i32> : i32
+  %acc_copy_seed = arith.constant 67 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_10x1xi8_times_1x10xi8_into_10x10xi32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 10 : i64
+  %k = arith.constant 1 : i64
+  %n = arith.constant 10 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_DYNxDYNxi8_times_DYNxDYNxi8_into_DYNxDYNxi32_10_10_1_acc_24() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 10x10x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 10 : i64
+  %lhs_dim1 = arith.constant 10 : i64
+  %lhs_element_type = hal.element_type<i8> : i32
+  %lhs_seed = arith.constant 68 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 10 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<i8> : i32
+  %rhs_seed = arith.constant 69 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 10 : i64
+  %acc_dim1 = arith.constant 1 : i64
+  %acc_element_type = hal.element_type<i32> : i32
+  %acc_seed = arith.constant 70 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 10 : i64
+  %acc_copy_dim1 = arith.constant 1 : i64
+  %acc_copy_element_type = hal.element_type<i32> : i32
+  %acc_copy_seed = arith.constant 70 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_DYNxDYNxi8_times_DYNxDYNxi8_into_DYNxDYNxi32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 10 : i64
+  %k = arith.constant 10 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_accumulate_10x10xi8_times_10x1xi8_into_10x1xi32_10_10_1_acc_25() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 10x10x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 10 : i64
+  %lhs_dim1 = arith.constant 10 : i64
+  %lhs_element_type = hal.element_type<i8> : i32
+  %lhs_seed = arith.constant 71 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 10 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<i8> : i32
+  %rhs_seed = arith.constant 72 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_dim0 = arith.constant 10 : i64
+  %acc_dim1 = arith.constant 1 : i64
+  %acc_element_type = hal.element_type<i32> : i32
+  %acc_seed = arith.constant 73 : i32
+  %acc = call @matmul_test.generate_random_matrix(%device, %acc_dim0, %acc_dim1, %acc_element_type, %acc_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc_copy_dim0 = arith.constant 10 : i64
+  %acc_copy_dim1 = arith.constant 1 : i64
+  %acc_copy_element_type = hal.element_type<i32> : i32
+  %acc_copy_seed = arith.constant 73 : i32
+  %acc_copy = call @matmul_test.generate_random_matrix(%device, %acc_copy_dim0, %acc_copy_dim1, %acc_copy_element_type, %acc_copy_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %result = call @module.matmul_accumulate_10x10xi8_times_10x1xi8_into_10x1xi32(%lhs, %rhs, %acc_copy) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 10 : i64
+  %k = arith.constant 10 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_DYNxDYNxi8_times_DYNxDYNxi8_into_DYNxDYNxi32_10_10_1_26() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 10x10x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 10 : i64
+  %lhs_dim1 = arith.constant 10 : i64
+  %lhs_element_type = hal.element_type<i8> : i32
+  %lhs_seed = arith.constant 74 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 10 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<i8> : i32
+  %rhs_seed = arith.constant 75 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_DYNxDYNxi8_times_DYNxDYNxi8_into_DYNxDYNxi32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 10 : i64
+  %k = arith.constant 10 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+func.func @matmul_10x10xi8_times_10x1xi8_into_10x1xi32_10_10_1_27() attributes {
+  iree.reflection = {description = "Matmul shape (MxKxN): 10x10x1"}
+} {
+  %device_index = arith.constant 0 : index
+  %device = hal.devices.get %device_index : !hal.device
+  %lhs_dim0 = arith.constant 10 : i64
+  %lhs_dim1 = arith.constant 10 : i64
+  %lhs_element_type = hal.element_type<i8> : i32
+  %lhs_seed = arith.constant 76 : i32
+  %lhs = call @matmul_test.generate_random_matrix(%device, %lhs_dim0, %lhs_dim1, %lhs_element_type, %lhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %rhs_dim0 = arith.constant 10 : i64
+  %rhs_dim1 = arith.constant 1 : i64
+  %rhs_element_type = hal.element_type<i8> : i32
+  %rhs_seed = arith.constant 77 : i32
+  %rhs = call @matmul_test.generate_random_matrix(%device, %rhs_dim0, %rhs_dim1, %rhs_element_type, %rhs_seed) : (!hal.device, i64, i64, i32, i32) -> !hal.buffer_view
+  %acc = util.null : !hal.buffer_view
+  %result = call @module.matmul_10x10xi8_times_10x1xi8_into_10x1xi32(%lhs, %rhs) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %m = arith.constant 10 : i64
+  %k = arith.constant 10 : i64
+  %n = arith.constant 1 : i64
+  %transpose_rhs = arith.constant 0 : i32
+  call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %lhs, %rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()
+  return
+}
+
+
+}

--- a/matmul/tests/generated/matmul_i8_i32_small_matmul.mlir
+++ b/matmul/tests/generated/matmul_i8_i32_small_matmul.mlir
@@ -1,0 +1,99 @@
+func.func @matmul_accumulate_DYNxDYNxi8_times_DYNxDYNxi8_into_DYNxDYNxi32(%lhs: tensor<?x?xi8>, %rhs: tensor<?x?xi8>, %acc: tensor<?x?xi32>) -> tensor<?x?xi32> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<?x?xi8>, tensor<?x?xi8>) outs(%acc: tensor<?x?xi32>) -> tensor<?x?xi32>
+  return %result: tensor<?x?xi32>
+}
+
+func.func @matmul_accumulate_1x1xi8_times_1x1xi8_into_1x1xi32(%lhs: tensor<1x1xi8>, %rhs: tensor<1x1xi8>, %acc: tensor<1x1xi32>) -> tensor<1x1xi32> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<1x1xi8>, tensor<1x1xi8>) outs(%acc: tensor<1x1xi32>) -> tensor<1x1xi32>
+  return %result: tensor<1x1xi32>
+}
+
+func.func @matmul_DYNxDYNxi8_times_DYNxDYNxi8_into_DYNxDYNxi32(%lhs: tensor<?x?xi8>, %rhs: tensor<?x?xi8>) -> tensor<?x?xi32> {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %acc_dim0 = tensor.dim %lhs, %c0 : tensor<?x?xi8>
+  %acc_dim1 = tensor.dim %rhs, %c1 : tensor<?x?xi8>
+  %init_acc = tensor.empty(%acc_dim0, %acc_dim1) : tensor<?x?xi32>
+  %c0_acc_type = arith.constant 0: i32
+  %acc = linalg.fill ins(%c0_acc_type : i32) outs(%init_acc : tensor<?x?xi32>) -> tensor<?x?xi32>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<?x?xi8>, tensor<?x?xi8>) outs(%acc: tensor<?x?xi32>) -> tensor<?x?xi32>
+  return %result: tensor<?x?xi32>
+}
+
+func.func @matmul_1x1xi8_times_1x1xi8_into_1x1xi32(%lhs: tensor<1x1xi8>, %rhs: tensor<1x1xi8>) -> tensor<1x1xi32> {
+  %init_acc = tensor.empty() : tensor<1x1xi32>
+  %c0_acc_type = arith.constant 0: i32
+  %acc = linalg.fill ins(%c0_acc_type : i32) outs(%init_acc : tensor<1x1xi32>) -> tensor<1x1xi32>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<1x1xi8>, tensor<1x1xi8>) outs(%acc: tensor<1x1xi32>) -> tensor<1x1xi32>
+  return %result: tensor<1x1xi32>
+}
+
+func.func @matmul_accumulate_2x2xi8_times_2x2xi8_into_2x2xi32(%lhs: tensor<2x2xi8>, %rhs: tensor<2x2xi8>, %acc: tensor<2x2xi32>) -> tensor<2x2xi32> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<2x2xi8>, tensor<2x2xi8>) outs(%acc: tensor<2x2xi32>) -> tensor<2x2xi32>
+  return %result: tensor<2x2xi32>
+}
+
+func.func @matmul_accumulate_4x4xi8_times_4x4xi8_into_4x4xi32(%lhs: tensor<4x4xi8>, %rhs: tensor<4x4xi8>, %acc: tensor<4x4xi32>) -> tensor<4x4xi32> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<4x4xi8>, tensor<4x4xi8>) outs(%acc: tensor<4x4xi32>) -> tensor<4x4xi32>
+  return %result: tensor<4x4xi32>
+}
+
+func.func @matmul_accumulate_8x8xi8_times_8x8xi8_into_8x8xi32(%lhs: tensor<8x8xi8>, %rhs: tensor<8x8xi8>, %acc: tensor<8x8xi32>) -> tensor<8x8xi32> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<8x8xi8>, tensor<8x8xi8>) outs(%acc: tensor<8x8xi32>) -> tensor<8x8xi32>
+  return %result: tensor<8x8xi32>
+}
+
+func.func @matmul_accumulate_9x9xi8_times_9x9xi8_into_9x9xi32(%lhs: tensor<9x9xi8>, %rhs: tensor<9x9xi8>, %acc: tensor<9x9xi32>) -> tensor<9x9xi32> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<9x9xi8>, tensor<9x9xi8>) outs(%acc: tensor<9x9xi32>) -> tensor<9x9xi32>
+  return %result: tensor<9x9xi32>
+}
+
+func.func @matmul_accumulate_6x13xi8_times_13x3xi8_into_6x3xi32(%lhs: tensor<6x13xi8>, %rhs: tensor<13x3xi8>, %acc: tensor<6x3xi32>) -> tensor<6x3xi32> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<6x13xi8>, tensor<13x3xi8>) outs(%acc: tensor<6x3xi32>) -> tensor<6x3xi32>
+  return %result: tensor<6x3xi32>
+}
+
+func.func @matmul_15x37xi8_times_37x7xi8_into_15x7xi32(%lhs: tensor<15x37xi8>, %rhs: tensor<37x7xi8>) -> tensor<15x7xi32> {
+  %init_acc = tensor.empty() : tensor<15x7xi32>
+  %c0_acc_type = arith.constant 0: i32
+  %acc = linalg.fill ins(%c0_acc_type : i32) outs(%init_acc : tensor<15x7xi32>) -> tensor<15x7xi32>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<15x37xi8>, tensor<37x7xi8>) outs(%acc: tensor<15x7xi32>) -> tensor<15x7xi32>
+  return %result: tensor<15x7xi32>
+}
+
+func.func @matmul_accumulate_81x19xi8_times_19x41xi8_into_81x41xi32(%lhs: tensor<81x19xi8>, %rhs: tensor<19x41xi8>, %acc: tensor<81x41xi32>) -> tensor<81x41xi32> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<81x19xi8>, tensor<19x41xi8>) outs(%acc: tensor<81x41xi32>) -> tensor<81x41xi32>
+  return %result: tensor<81x41xi32>
+}
+
+func.func @matmul_accumulate_1x10xi8_times_10x10xi8_into_1x10xi32(%lhs: tensor<1x10xi8>, %rhs: tensor<10x10xi8>, %acc: tensor<1x10xi32>) -> tensor<1x10xi32> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<1x10xi8>, tensor<10x10xi8>) outs(%acc: tensor<1x10xi32>) -> tensor<1x10xi32>
+  return %result: tensor<1x10xi32>
+}
+
+func.func @matmul_1x10xi8_times_10x10xi8_into_1x10xi32(%lhs: tensor<1x10xi8>, %rhs: tensor<10x10xi8>) -> tensor<1x10xi32> {
+  %init_acc = tensor.empty() : tensor<1x10xi32>
+  %c0_acc_type = arith.constant 0: i32
+  %acc = linalg.fill ins(%c0_acc_type : i32) outs(%init_acc : tensor<1x10xi32>) -> tensor<1x10xi32>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<1x10xi8>, tensor<10x10xi8>) outs(%acc: tensor<1x10xi32>) -> tensor<1x10xi32>
+  return %result: tensor<1x10xi32>
+}
+
+func.func @matmul_accumulate_10x1xi8_times_1x10xi8_into_10x10xi32(%lhs: tensor<10x1xi8>, %rhs: tensor<1x10xi8>, %acc: tensor<10x10xi32>) -> tensor<10x10xi32> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<10x1xi8>, tensor<1x10xi8>) outs(%acc: tensor<10x10xi32>) -> tensor<10x10xi32>
+  return %result: tensor<10x10xi32>
+}
+
+func.func @matmul_accumulate_10x10xi8_times_10x1xi8_into_10x1xi32(%lhs: tensor<10x10xi8>, %rhs: tensor<10x1xi8>, %acc: tensor<10x1xi32>) -> tensor<10x1xi32> {
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<10x10xi8>, tensor<10x1xi8>) outs(%acc: tensor<10x1xi32>) -> tensor<10x1xi32>
+  return %result: tensor<10x1xi32>
+}
+
+func.func @matmul_10x10xi8_times_10x1xi8_into_10x1xi32(%lhs: tensor<10x10xi8>, %rhs: tensor<10x1xi8>) -> tensor<10x1xi32> {
+  %init_acc = tensor.empty() : tensor<10x1xi32>
+  %c0_acc_type = arith.constant 0: i32
+  %acc = linalg.fill ins(%c0_acc_type : i32) outs(%init_acc : tensor<10x1xi32>) -> tensor<10x1xi32>
+  %result = linalg.matmul ins(%lhs, %rhs: tensor<10x10xi8>, tensor<10x1xi8>) outs(%acc: tensor<10x1xi32>) -> tensor<10x1xi32>
+  return %result: tensor<10x1xi32>
+}
+


### PR DESCRIPTION
Progress on https://github.com/iree-org/iree-test-suites/issues/2

This runs the generator script using some of the option combinations found in the CMakeLists.txt so we can look at what it generates. This does _not_ set `--transpose_rhs` or `--compilation_info` yet.

Some observations:

* I'm not sure if grouping by "shape" in the source files will continue to be useful. I'd rather split these out into one file per test case. We can add sharding and batching up a level in the test runner. I guess this does let us feed multiple modules in to the compiler at the same time, at least.
* We can decouple compiler flags, test tags, CPU features, runtime flags, and similar properties from these generated test files.
* I would like to also decouple the compilation info parameter - that feels like a meta property that should come through compilation flags, not be part of the test sources.