### PR TITLE
Make matmul generator acc_type argument required/explicit.

### DIFF
--- a/matmul/tests/CMakeLists.txt
+++ b/matmul/tests/CMakeLists.txt
@@ -1835,6 +1835,7 @@ iree_generated_e2e_runner_test(
     "generate_e2e_matmul_tests.py"
   GENERATOR_ARGS
     "--lhs_rhs_type=i8"
+    "--acc_type=i32"
     "--shapes=small"
   TEST_RUNNER
     iree-test-suites_iree-e2e-matmul-test
@@ -1856,6 +1857,7 @@ iree_generated_e2e_runner_test(
     "generate_e2e_matmul_tests.py"
   GENERATOR_ARGS
     "--lhs_rhs_type=f32"
+    "--acc_type=f32"
     "--shapes=small"
   TEST_RUNNER
     iree-test-suites_iree-e2e-matmul-test
@@ -1929,6 +1931,7 @@ iree_generated_e2e_runner_test(
     "generate_e2e_matmul_tests.py"
   GENERATOR_ARGS
     "--lhs_rhs_type=f32"
+    "--acc_type=f32"
     "--shapes=gpu_large"
   TEST_RUNNER
     iree-test-suites_iree-e2e-matmul-test
@@ -1955,6 +1958,7 @@ iree_generated_e2e_runner_test(
     "generate_e2e_matmul_tests.py"
   GENERATOR_ARGS
     "--lhs_rhs_type=f16"
+    "--acc_type=f32"
     "--shapes=gpu_large"
   TEST_RUNNER
     iree-test-suites_iree-e2e-matmul-test
@@ -2062,6 +2066,7 @@ iree_generated_e2e_runner_test(
     "generate_e2e_matmul_tests.py"
   GENERATOR_ARGS
     "--lhs_rhs_type=f32"
+    "--acc_type=f32"
     "--shapes=large"
   TEST_RUNNER
     iree-test-suites_iree-e2e-matmul-test

--- a/matmul/tests/generate_e2e_matmul_tests.py
+++ b/matmul/tests/generate_e2e_matmul_tests.py
@@ -876,9 +876,9 @@ def parse_arguments():
         "--acc_type",
         type=str,
         choices=["i32", "f32", "f16", "bf16"],
-        help="Numeric type of input matrices",
+        help="Numeric type of accumulator",
         default="",
-        required=False,
+        required=True,
     )
     parser.add_argument(
         "--shapes",
@@ -954,24 +954,9 @@ def write_calls_file(functions, calls, filename, requirements):
         file.write(module_definition)
 
 
-# For now, the accumulator type can always be inferred from the input LHS/RHS
-# type, so we do that. That is temporary: eventually there will be cases
-# where the same input types are used with different accumulator types, e.g.
-# f16 inputs with both f16 and f32 accumulator.
-def infer_acc_type(lhs_rhs_type: MatrixElemTypeId, acc_type: MatrixElemTypeId):
-    if acc_type != MatrixElemTypeId.NONE:
-        return acc_type
-    if lhs_rhs_type == MatrixElemTypeId.F8E4M3FNUZ:
-        return MatrixElemTypeId.F32
-    if lhs_rhs_type == MatrixElemTypeId.I8:
-        return MatrixElemTypeId.I32
-    return lhs_rhs_type
-
-
 def main(args):
     lhs_rhs_type = MatrixElemTypeId(args.lhs_rhs_type)
     acc_type = MatrixElemTypeId(args.acc_type)
-    acc_type = infer_acc_type(lhs_rhs_type, acc_type)
     shapes_id = ShapesId(args.shapes)
     compilation_info_id = CompilationInfoId(args.compilation_info)
 


### PR DESCRIPTION
The comment on `infer_acc_type` was outdated and making the argument required will simplify the generator.