### PR TITLE
Only enable hip tests if IREE_HIP_TEST_TARGET_CHIP is set.

### DIFF
--- a/linalg_ops/matmul/CMakeLists.txt
+++ b/linalg_ops/matmul/CMakeLists.txt
@@ -161,6 +161,8 @@ endforeach()
 #
 ###############################################################################
 
+if(IREE_HIP_TEST_TARGET_CHIP)
+
 set(_DTYPES)
 list(APPEND _DTYPES "i8_into_i32")
 list(APPEND _DTYPES "f32_into_f32")
@@ -191,3 +193,5 @@ foreach(_DTYPE IN LISTS _DTYPES)
     )
   endforeach()
 endforeach()
+
+endif()


### PR DESCRIPTION
This fixes the build error reported here: https://github.com/iree-org/iree-test-suites/pull/22#issuecomment-2414925619