### PR TITLE
Fix mismatch between CMake option names.

### DIFF
--- a/linalg_ops/iree_test_suites_runner_test.cmake
+++ b/linalg_ops/iree_test_suites_runner_test.cmake
@@ -18,9 +18,9 @@ include(CMakeParseArguments)
 #   TEST_RUNNER: Test runner program.
 #   TARGET_BACKEND: Target backend to compile for.
 #   DRIVER: Driver to run the module with.
-#   COMPILER_ARGS: additional args to pass to the compiler.
+#   COMPILER_FLAGS: additional args to pass to the compiler.
 #       Target backend flags are passed automatically.
-#   RUNNER_ARGS: Additional args to pass to the runner program.
+#   RUNNER_FLAGS: Additional args to pass to the runner program.
 #       The device and input file flags are passed automatically.
 #   LABELS: Additional labels to apply to the test.
 #       "driver=${DRIVER}" is added automatically.
@@ -29,7 +29,7 @@ function(iree_test_suites_runner_test)
     _RULE
     ""
     "NAME;TESTS_SRC;CALLS_SRC;TEST_RUNNER;TARGET_BACKEND;DRIVER"
-    "COMPILER_ARGS;RUNNER_ARGS;LABELS"
+    "COMPILER_FLAGS;RUNNER_FLAGS;LABELS"
     ${ARGN}
   )
 
@@ -91,7 +91,7 @@ function(iree_test_suites_runner_test)
     ARGS
       "--module={{${_TESTS_VMFB}}}"
       "--module={{${_CALLS_VMFB}}}"
-      ${_RULE_RUNNER_ARGS}
+      ${_RULE_RUNNER_FLAGS}
     LABELS
       ${_RULE_LABELS}
     DISABLED

--- a/linalg_ops/matmul/CMakeLists.txt
+++ b/linalg_ops/matmul/CMakeLists.txt
@@ -40,8 +40,8 @@ foreach(_DTYPE IN LISTS _DTYPES)
         "llvm-cpu"
       DRIVER
         "local-task"
-      COMPILER_ARGS
-      RUNNER_ARGS
+      COMPILER_FLAGS
+      RUNNER_FLAGS
       LABELS
     )
   endforeach()
@@ -77,8 +77,8 @@ foreach(_DTYPE IN LISTS _DTYPES)
       "vmvx"
     DRIVER
       "local-task"
-    COMPILER_ARGS
-    RUNNER_ARGS
+    COMPILER_FLAGS
+    RUNNER_FLAGS
     LABELS
   )
 endforeach()
@@ -112,8 +112,8 @@ foreach(_DTYPE IN LISTS _DTYPES)
         "vulkan-spirv"
       DRIVER
         "vulkan"
-      COMPILER_ARGS
-      RUNNER_ARGS
+      COMPILER_FLAGS
+      RUNNER_FLAGS
       LABELS
     )
   endforeach()
@@ -148,8 +148,8 @@ foreach(_DTYPE IN LISTS _DTYPES)
         "cuda"
       DRIVER
         "cuda"
-      COMPILER_ARGS
-      RUNNER_ARGS
+      COMPILER_FLAGS
+      RUNNER_FLAGS
       LABELS
     )
   endforeach()
@@ -186,9 +186,9 @@ foreach(_DTYPE IN LISTS _DTYPES)
         "rocm"
       DRIVER
         "hip"
-      COMPILER_ARGS
+      COMPILER_FLAGS
         "--iree-hip-target=${IREE_HIP_TEST_TARGET_CHIP}"
-      RUNNER_ARGS
+      RUNNER_FLAGS
       LABELS
     )
   endforeach()


### PR DESCRIPTION
The `COMPILER_ARGS` option was getting ignored since `COMPILER_FLAGS` is what the helper function was checking.

Probably some copy/paste bug when forking from https://github.com/iree-org/iree/blob/main/build_tools/cmake/iree_e2e_generated_runner_test.cmake where `COMPILER_FLAGS` and `RUNNER_ARGS` are used. I think it makes sense to just call both `ARGS` or `FLAGS`.