### PR TITLE
Import tests for all remaining validated/vision/ folders.

### DIFF
--- a/.github/workflows/test_onnx_models.yml
+++ b/.github/workflows/test_onnx_models.yml
@@ -57,5 +57,5 @@ jobs:
           pytest onnx_models/ \
             -rA \
             --log-cli-level=info \
-            --timeout=120 \
+            --timeout=300 \
             --durations=0

--- a/onnx_models/README.md
+++ b/onnx_models/README.md
@@ -63,11 +63,11 @@ graph LR
     pytest -k resnet
     ```
 
-* Skip "medium" sized tests using custom markers
+* Skip "large" tests using custom markers
   (https://docs.pytest.org/en/stable/example/markers.html):
 
     ```bash
-    pytest -m "not size_medium"
+    pytest -m "not size_large"
     ```
 
 * Ignore xfail marks

--- a/onnx_models/pytest.ini
+++ b/onnx_models/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
 xfail_strict=true
 markers =
-    size_medium: mark tests as being "medium" size (500MB+ data, 30 seconds+ runtime)
+    size_large: mark tests as being "large" size (500MB+ data, 30 seconds+ runtime)

--- a/onnx_models/tests/model_zoo/validated/vision/body_analysis_models_test.py
+++ b/onnx_models/tests/model_zoo/validated/vision/body_analysis_models_test.py
@@ -1,0 +1,64 @@
+# Copyright 2024 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# https://github.com/onnx/models/tree/main/validated/vision/body_analysis/
+
+import pytest
+
+from .....utils import *
+
+artifacts_subdir = "model_zoo/validated/vision/body_analysis"
+
+
+def test_age_gender_age_googlenet(compare_between_iree_and_onnxruntime):
+    compare_between_iree_and_onnxruntime(
+        model_url="https://github.com/onnx/models/raw/main/validated/vision/body_analysis/age_gender/models/age_googlenet.onnx",
+        artifacts_subdir=artifacts_subdir,
+    )
+
+
+def test_age_gender_gender_googlenet(compare_between_iree_and_onnxruntime):
+    compare_between_iree_and_onnxruntime(
+        model_url="https://github.com/onnx/models/raw/main/validated/vision/body_analysis/age_gender/models/gender_googlenet.onnx",
+        artifacts_subdir=artifacts_subdir,
+    )
+
+
+@pytest.mark.size_medium
+def test_age_gender_vgg_ilsvrc_16_age_imdb_wiki(compare_between_iree_and_onnxruntime):
+    compare_between_iree_and_onnxruntime(
+        model_url="https://github.com/onnx/models/raw/main/validated/vision/body_analysis/age_gender/models/vgg_ilsvrc_16_age_imdb_wiki.onnx",
+        artifacts_subdir=artifacts_subdir,
+    )
+
+
+@pytest.mark.size_medium
+def test_age_gender_vgg_ilsvrc_16_gender_imdb_wiki(
+    compare_between_iree_and_onnxruntime,
+):
+    compare_between_iree_and_onnxruntime(
+        model_url="https://github.com/onnx/models/raw/main/validated/vision/body_analysis/age_gender/model/vgg_ilsvrc_16_gender_imdb_wiki.onnx",
+        artifacts_subdir=artifacts_subdir,
+    )
+
+
+def test_emotion_ferplus(
+    compare_between_iree_and_onnxruntime,
+):
+    compare_between_iree_and_onnxruntime(
+        model_url="https://github.com/onnx/models/raw/main/validated/vision/body_analysis/emotion_ferplus/model/emotion-ferplus-8.onnx",
+        artifacts_subdir=artifacts_subdir,
+    )
+
+
+@pytest.mark.skip("ONNXRuntimeError")
+def test_ultraface(
+    compare_between_iree_and_onnxruntime,
+):
+    compare_between_iree_and_onnxruntime(
+        model_url="https://github.com/onnx/models/raw/main/validated/vision/body_analysis/ultraface/models/version-RFB-320.onnx",
+        artifacts_subdir=artifacts_subdir,
+    )

--- a/onnx_models/tests/model_zoo/validated/vision/body_analysis_models_test.py
+++ b/onnx_models/tests/model_zoo/validated/vision/body_analysis_models_test.py
@@ -27,7 +27,7 @@ def test_age_gender_gender_googlenet(compare_between_iree_and_onnxruntime):
     )
 
 
-@pytest.mark.size_medium
+@pytest.mark.size_large
 def test_age_gender_vgg_ilsvrc_16_age_imdb_wiki(compare_between_iree_and_onnxruntime):
     compare_between_iree_and_onnxruntime(
         model_url="https://github.com/onnx/models/raw/main/validated/vision/body_analysis/age_gender/models/vgg_ilsvrc_16_age_imdb_wiki.onnx",
@@ -35,12 +35,12 @@ def test_age_gender_vgg_ilsvrc_16_age_imdb_wiki(compare_between_iree_and_onnxrun
     )
 
 
-@pytest.mark.size_medium
+@pytest.mark.size_large
 def test_age_gender_vgg_ilsvrc_16_gender_imdb_wiki(
     compare_between_iree_and_onnxruntime,
 ):
     compare_between_iree_and_onnxruntime(
-        model_url="https://github.com/onnx/models/raw/main/validated/vision/body_analysis/age_gender/model/vgg_ilsvrc_16_gender_imdb_wiki.onnx",
+        model_url="https://github.com/onnx/models/raw/main/validated/vision/body_analysis/age_gender/models/vgg_ilsvrc_16_gender_imdb_wiki.onnx",
         artifacts_subdir=artifacts_subdir,
     )
 

--- a/onnx_models/tests/model_zoo/validated/vision/classification_models_test.py
+++ b/onnx_models/tests/model_zoo/validated/vision/classification_models_test.py
@@ -122,7 +122,7 @@ def test_squeezenet(compare_between_iree_and_onnxruntime):
     )
 
 
-@pytest.mark.size_medium
+@pytest.mark.size_large
 def test_vgg19(compare_between_iree_and_onnxruntime):
     compare_between_iree_and_onnxruntime(
         model_url="https://github.com/onnx/models/raw/main/validated/vision/classification/vgg/model/vgg19-7.onnx",
@@ -130,7 +130,7 @@ def test_vgg19(compare_between_iree_and_onnxruntime):
     )
 
 
-@pytest.mark.size_medium
+@pytest.mark.size_large
 @pytest.mark.xfail(raises=IreeCompileException)
 def test_zfnet_512(compare_between_iree_and_onnxruntime):
     compare_between_iree_and_onnxruntime(

--- a/onnx_models/tests/model_zoo/validated/vision/object_detection_segmentation_models_test.py
+++ b/onnx_models/tests/model_zoo/validated/vision/object_detection_segmentation_models_test.py
@@ -1,0 +1,107 @@
+# Copyright 2024 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# https://github.com/onnx/models/tree/main/validated/vision/object_detection_segmentation/
+
+import pytest
+
+from .....utils import *
+
+artifacts_subdir = "model_zoo/validated/vision/object_detection_segmentation"
+
+
+@pytest.mark.size_medium
+def test_duc(compare_between_iree_and_onnxruntime):
+    compare_between_iree_and_onnxruntime(
+        model_url="https://github.com/onnx/models/raw/main/validated/vision/object_detection_segmentation/duc/model/ResNet101-DUC-12.onnx",
+        artifacts_subdir=artifacts_subdir,
+    )
+
+
+@pytest.mark.xfail(raises=IreeCompileException)
+def test_faster_rcnn(compare_between_iree_and_onnxruntime):
+    compare_between_iree_and_onnxruntime(
+        model_url="https://github.com/onnx/models/raw/main/validated/vision/object_detection_segmentation/faster-rcnn/model/FasterRCNN-12.onnx",
+        artifacts_subdir=artifacts_subdir,
+    )
+
+
+@pytest.mark.xfail(raises=IreeRunException)
+def test_fcn(compare_between_iree_and_onnxruntime):
+    compare_between_iree_and_onnxruntime(
+        model_url="https://github.com/onnx/models/raw/main/validated/vision/object_detection_segmentation/fcn/model/fcn-resnet50-12.onnx",
+        artifacts_subdir=artifacts_subdir,
+    )
+
+
+@pytest.mark.xfail(raises=IreeCompileException)
+def test_mask_rcnn(compare_between_iree_and_onnxruntime):
+    compare_between_iree_and_onnxruntime(
+        model_url="https://github.com/onnx/models/raw/main/validated/vision/object_detection_segmentation/mask-rcnn/model/MaskRCNN-12.onnx",
+        artifacts_subdir=artifacts_subdir,
+    )
+
+
+@pytest.mark.xfail(raises=IreeRunException)
+def test_retinanet(compare_between_iree_and_onnxruntime):
+    compare_between_iree_and_onnxruntime(
+        model_url="https://github.com/onnx/models/raw/main/validated/vision/object_detection_segmentation/retinanet/model/retinanet-9.onnx",
+        artifacts_subdir=artifacts_subdir,
+    )
+
+
+@pytest.mark.xfail(raises=IreeCompileException)
+def test_ssd(compare_between_iree_and_onnxruntime):
+    compare_between_iree_and_onnxruntime(
+        model_url="https://github.com/onnx/models/raw/main/validated/vision/object_detection_segmentation/ssd/model/ssd-12.onnx",
+        artifacts_subdir=artifacts_subdir,
+    )
+
+
+@pytest.mark.xfail(raises=NotImplementedError)  # numpy.uint8
+def test_ssd_mobilenetv1(compare_between_iree_and_onnxruntime):
+    compare_between_iree_and_onnxruntime(
+        model_url="https://github.com/onnx/models/raw/main/validated/vision/object_detection_segmentation/ssd-mobilenetv1/model/ssd_mobilenet_v1_12.onnx",
+        artifacts_subdir=artifacts_subdir,
+    )
+
+
+def test_tiny_yolov2(compare_between_iree_and_onnxruntime):
+    compare_between_iree_and_onnxruntime(
+        model_url="https://github.com/onnx/models/raw/main/validated/vision/object_detection_segmentation/tiny-yolov2/model/tinyyolov2-8.onnx",
+        artifacts_subdir=artifacts_subdir,
+    )
+
+
+@pytest.mark.skip("ONNXRuntimeError")
+def test_tiny_yolov3(compare_between_iree_and_onnxruntime):
+    compare_between_iree_and_onnxruntime(
+        model_url="https://github.com/onnx/models/raw/main/validated/vision/object_detection_segmentation/tiny-yolov3/model/tiny-yolov3-11.onnx",
+        artifacts_subdir=artifacts_subdir,
+    )
+
+
+def test_yolov2_coco(compare_between_iree_and_onnxruntime):
+    compare_between_iree_and_onnxruntime(
+        model_url="https://github.com/onnx/models/raw/main/validated/vision/object_detection_segmentation/yolov2-coco/model/yolov2-coco-9.onnx",
+        artifacts_subdir=artifacts_subdir,
+    )
+
+
+@pytest.mark.skip("ONNXRuntimeError")
+def test_yolov3(compare_between_iree_and_onnxruntime):
+    compare_between_iree_and_onnxruntime(
+        model_url="https://github.com/onnx/models/raw/main/validated/vision/object_detection_segmentation/yolov3/model/yolov3-12.onnx",
+        artifacts_subdir=artifacts_subdir,
+    )
+
+
+@pytest.mark.xfail(raises=IreeRunException)
+def test_yolov4(compare_between_iree_and_onnxruntime):
+    compare_between_iree_and_onnxruntime(
+        model_url="https://github.com/onnx/models/raw/main/validated/vision/object_detection_segmentation/yolov4/model/yolov4.onnx",
+        artifacts_subdir=artifacts_subdir,
+    )

--- a/onnx_models/tests/model_zoo/validated/vision/object_detection_segmentation_models_test.py
+++ b/onnx_models/tests/model_zoo/validated/vision/object_detection_segmentation_models_test.py
@@ -13,7 +13,7 @@ from .....utils import *
 artifacts_subdir = "model_zoo/validated/vision/object_detection_segmentation"
 
 
-@pytest.mark.size_medium
+@pytest.mark.size_large
 def test_duc(compare_between_iree_and_onnxruntime):
     compare_between_iree_and_onnxruntime(
         model_url="https://github.com/onnx/models/raw/main/validated/vision/object_detection_segmentation/duc/model/ResNet101-DUC-12.onnx",

--- a/onnx_models/tests/model_zoo/validated/vision/style_transfer_models_test.py
+++ b/onnx_models/tests/model_zoo/validated/vision/style_transfer_models_test.py
@@ -1,0 +1,21 @@
+# Copyright 2024 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# https://github.com/onnx/models/tree/main/validated/vision/style_transfer/
+
+import pytest
+
+from .....utils import *
+
+artifacts_subdir = "model_zoo/validated/vision/style_transfer"
+
+
+@pytest.mark.xfail(raises=IreeCompileException)
+def test_fast_neural_style(compare_between_iree_and_onnxruntime):
+    compare_between_iree_and_onnxruntime(
+        model_url="https://github.com/onnx/models/raw/main/validated/vision/style_transfer/fast_neural_style/model/mosaic-9.onnx",
+        artifacts_subdir=artifacts_subdir,
+    )

--- a/onnx_models/tests/model_zoo/validated/vision/super_resolution_models_test.py
+++ b/onnx_models/tests/model_zoo/validated/vision/super_resolution_models_test.py
@@ -1,0 +1,20 @@
+# Copyright 2024 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# https://github.com/onnx/models/tree/main/validated/vision/super_resolution/
+
+import pytest
+
+from .....utils import *
+
+artifacts_subdir = "model_zoo/validated/vision/super_resolution"
+
+
+def test_fast_neural_style(compare_between_iree_and_onnxruntime):
+    compare_between_iree_and_onnxruntime(
+        model_url="https://github.com/onnx/models/raw/main/validated/vision/super_resolution/sub_pixel_cnn_2016/model/super-resolution-10.onnx",
+        artifacts_subdir=artifacts_subdir,
+    )


### PR DESCRIPTION
This test suite now contains all model categories from https://github.com/onnx/models/tree/main/validated/vision.

## Test cases diff

Description | Logs | Summary
-- | -- | --
Before | https://github.com/iree-org/iree-test-suites/actions/runs/11965059466/job/33358435820 | `12 passed, 5 xfailed in 160.89s`
After | https://github.com/iree-org/iree-test-suites/actions/runs/11965072359/job/33358474549?pr=46 | `21 passed, 3 skipped, 13 xfailed in 444.04s`

Note that downstream can choose to run with `pytest -m "not size_large"` to exclude the especially large tests.

## Details of added tests

I did not add test cases for duplicates, even though some may be useful to test. For example the https://github.com/onnx/models/tree/main/validated/vision/object_detection_segmentation/duc/model folder has these files:
* `ResNet101-DUC-12-int8.onnx`
* `ResNet101-DUC-12.onnx`
* `ResNet101-DUC-7.onnx`

I only added a test case for `ResNet101-DUC-12.onnx`

Tests were mostly added manually (file tree --> multi-cursor editing in VSCode). A script would have helped a bit.