### PR TITLE
Mark onnx model test_mobilenet as passing.

### DIFF
--- a/onnx_models/tests/model_zoo/validated/vision/classification_models_test.py
+++ b/onnx_models/tests/model_zoo/validated/vision/classification_models_test.py
@@ -71,7 +71,6 @@ def test_mnist(compare_between_iree_and_onnxruntime):
     )
 
 
-@pytest.mark.xfail(raises=IreeRunException)
 def test_mobilenet(compare_between_iree_and_onnxruntime):
     compare_between_iree_and_onnxruntime(
         model_url="https://github.com/onnx/models/raw/main/validated/vision/classification/mobilenet/model/mobilenetv2-12.onnx",


### PR DESCRIPTION
Flagged by this nightly CI run: https://github.com/iree-org/iree-test-suites/actions/runs/12201314112.

Fixed by https://github.com/iree-org/iree/pull/19356. I linked some logs at https://github.com/iree-org/iree/pull/19356#issuecomment-2523547585.