### PR TITLE
Migrate to flash attention for attention operation

### DIFF
--- a/sharktank_models/llama3.1/assets/toy_llama.mlir
+++ b/sharktank_models/llama3.1/assets/toy_llama.mlir
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7172acdf43cb26a9609bcb969d98679a0829a28ef23d39141be24699d224a85c
-size 349994
+oid sha256:0ca8ffdb39d1aaeeb648a8ba43f852e34c1b94d94a36780baa40b6aeef89a444
+size 322201

--- a/sharktank_models/llama3.1/assets/toy_llama.mlir
+++ b/sharktank_models/llama3.1/assets/toy_llama.mlir
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0ca8ffdb39d1aaeeb648a8ba43f852e34c1b94d94a36780baa40b6aeef89a444
-size 322201
+oid sha256:e142743af5ce5242fdfb9d4e1f67a5fc81f340488e57e4f3f2d31e5274a8bee2
+size 241733

--- a/sharktank_models/llama3.1/assets/toy_llama_tp2.mlir
+++ b/sharktank_models/llama3.1/assets/toy_llama_tp2.mlir
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b0143818f2ab4ad2e2071c2b6b066f977818857b8ebd74359c8d05ba8f8dfc84
-size 770388
+oid sha256:482b9d6dc3415e4f6785da32c2112468193e294fadf96c3b60b2dbbd8f826f76
+size 491855

--- a/sharktank_models/llama3.1/assets/toy_llama_tp2.mlir
+++ b/sharktank_models/llama3.1/assets/toy_llama_tp2.mlir
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b7b2f5a20663ee53d836412d5a7575a45c321e64e1c5a241bac3c328366ac954
-size 829277
+oid sha256:b0143818f2ab4ad2e2071c2b6b066f977818857b8ebd74359c8d05ba8f8dfc84
+size 770388

--- a/sharktank_models/llama3.1/test_llama.py
+++ b/sharktank_models/llama3.1/test_llama.py
@@ -11,8 +11,8 @@ import os
 import pathlib
 import pytest
 
-page_size = 12288
-block_size = 16
+block_size = 32
+page_size = 768 * block_size
 
 THIS_DIR = pathlib.Path(__file__).parent
 llama_mlir = str(THIS_DIR / "assets/toy_llama.mlir")
@@ -235,5 +235,5 @@ def test_prefill_decode(toy_llama):
     cross_entropy = prefill_decode_cross_entropy(toy_llama, ids)
     cross_entropy = cross_entropy.item()
     assert cross_entropy == pytest.approx(
-        0.589, 1e-2
+        0.589, 1e-1
     ), "cross entropy outside of tolerance"

--- a/sharktank_models/llama3.1/test_llama.py
+++ b/sharktank_models/llama3.1/test_llama.py
@@ -11,8 +11,9 @@ import os
 import pathlib
 import pytest
 
+kv_size = 768
 block_size = 32
-page_size = 768 * block_size
+page_size = kv_size * block_size
 
 THIS_DIR = pathlib.Path(__file__).parent
 llama_mlir = str(THIS_DIR / "assets/toy_llama.mlir")
@@ -109,7 +110,7 @@ class ToyLlama:
 
 
 def cpu_flags(sharding):
-    return ["--iree-hal-target-device=llvm-cpu"] * sharding + [
+    return [f"--iree-hal-target-device=llvm-cpu[{i}]" for i in range(sharding)] + [
         "--iree-llvmcpu-target-cpu=host"
     ]
 
@@ -235,5 +236,5 @@ def test_prefill_decode(toy_llama):
     cross_entropy = prefill_decode_cross_entropy(toy_llama, ids)
     cross_entropy = cross_entropy.item()
     assert cross_entropy == pytest.approx(
-        0.589, 1e-1
+        0.589, 1e-2
     ), "cross entropy outside of tolerance"


### PR DESCRIPTION
Previous version was based on decopmosed attention for prefill and
decode. This migrates to flash attention instead and changes blocking
size to 32.

Signed-off-by: Rob Suderman <rob.suderman@gmail.com>