### PR TITLE
[NFC] Fix a typo in README.md (HTMl -> HTML)

### DIFF
--- a/onnx_models/README.md
+++ b/onnx_models/README.md
@@ -88,7 +88,7 @@ graph LR
     pytest -n 4
     ```
 
-* Create an HTMl report using https://pytest-html.readthedocs.io/en/latest/index.html
+* Create an HTML report using https://pytest-html.readthedocs.io/en/latest/index.html
 
     ```bash
     pytest --html=report.html --self-contained-html --log-cli-level=info

--- a/sharktank_models/README.md
+++ b/sharktank_models/README.md
@@ -89,7 +89,7 @@ built as part of the [shark-ai project](https://github.com/nod-ai/shark-ai).
     pytest -n 4
     ```
 
-* Create an HTMl report using https://pytest-html.readthedocs.io/en/latest/index.html
+* Create an HTML report using https://pytest-html.readthedocs.io/en/latest/index.html
 
     ```bash
     pytest --html=report.html --self-contained-html --log-cli-level=info


### PR DESCRIPTION
It turns `l` from lowercase to uppercase.