### PR TITLE
Pin github action versions to commit hashes.

### DIFF
--- a/.github/workflows/test_linalg_ops.yml
+++ b/.github/workflows/test_linalg_ops.yml
@@ -40,11 +40,11 @@ jobs:
       CXX: clang++
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       # Install Python packages.
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
         with:
           python-version: "3.11"
       - name: Setup Python venv

--- a/.github/workflows/test_litert_models.yml
+++ b/.github/workflows/test_litert_models.yml
@@ -38,11 +38,11 @@ jobs:
       HTML_REPORT_PATH: litert_models/litert_models_test_report_cpu_llvm_task.html
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       # Install Python packages.
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
         with:
           python-version: "3.11"
       - name: Setup Python venv
@@ -65,7 +65,7 @@ jobs:
             --self-contained-html
 
       - name: Upload HTML report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: litert_models_test_report_cpu_llvm_task.html
           path: ${{ env.HTML_REPORT_PATH }}

--- a/.github/workflows/test_onnx_models.yml
+++ b/.github/workflows/test_onnx_models.yml
@@ -38,11 +38,11 @@ jobs:
       HTML_REPORT_PATH: onnx_models/onnx_models_test_report_cpu_llvm_task.html
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       # Install Python packages.
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
         with:
           python-version: "3.11"
       - name: Setup Python venv
@@ -65,7 +65,7 @@ jobs:
             --self-contained-html
 
       - name: Upload HTML report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: onnx_models_test_report_cpu_llvm_task.html
           path: ${{ env.HTML_REPORT_PATH }}

--- a/.github/workflows/test_onnx_ops.yml
+++ b/.github/workflows/test_onnx_ops.yml
@@ -39,11 +39,11 @@ jobs:
       HTML_REPORT_PATH: onnx_ops/onnx_ops_test_report_cpu_llvm_sync.html
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       # Install Python packages.
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
         with:
           python-version: "3.11"
       - name: Setup Python venv
@@ -68,7 +68,7 @@ jobs:
             --report-log=/tmp/onnx_ops_cpu_logs.json \
             --config-files=${CONFIG_FILE_PATH}
       - name: Upload HTML report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: onnx_ops_test_report_cpu_llvm_sync.html
           path: ${{ env.HTML_REPORT_PATH }}
@@ -80,7 +80,7 @@ jobs:
             --config-file=${CONFIG_FILE_PATH}
           cat ${CONFIG_FILE_PATH}
       - name: Upload new config file
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: onnx_ops_cpu_llvm_sync.json
           path: ${{ env.CONFIG_FILE_PATH }}

--- a/.github/workflows/test_sharktank_models.yml
+++ b/.github/workflows/test_sharktank_models.yml
@@ -38,13 +38,13 @@ jobs:
       HTML_REPORT_PATH: sharktank_models/sharktank_models_test_report_cpu_llvm_task.html
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
 
       # Install Python packages.
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
         with:
           python-version: "3.11"
       - name: Setup Python venv
@@ -68,7 +68,7 @@ jobs:
             --self-contained-html
 
       - name: Upload HTML report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: sharktank_models_test_report_cpu_llvm_task.html
           path: ${{ env.HTML_REPORT_PATH }}


### PR DESCRIPTION
Actions are pinned with hashes as suggested by OpenSSF Scorecard, see https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies.