### PR TITLE
Implement caching for onnx/models git LFS files.

### DIFF
--- a/.github/workflows/test_onnx_models.yml
+++ b/.github/workflows/test_onnx_models.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
+      - name: Install Git LFS
+        run: sudo apt install -y git-lfs
+
       # Install Python packages.
       - name: Setup Python
         uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0

--- a/.github/workflows/test_onnx_models.yml
+++ b/.github/workflows/test_onnx_models.yml
@@ -40,9 +40,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Install Git LFS
-        run: sudo apt install -y git-lfs
-
       # Install Python packages.
       - name: Setup Python
         uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0

--- a/onnx_models/README.md
+++ b/onnx_models/README.md
@@ -208,4 +208,5 @@ iree-run-module \
 
 Test input files from https://github.com/onnx/models are cached by default at a
 local git checkout stored at `~/.cache/iree-test-suites/onnx_models`. The cache
-location can be changed by passing `--cache-dir=/path/to/cache`.
+location can be changed by passing `--cache-dir=/path/to/cache` or by setting
+the `IREE_TEST_FILES` environment variable.

--- a/onnx_models/README.md
+++ b/onnx_models/README.md
@@ -21,7 +21,14 @@ graph LR
 
 ## Quickstart
 
-1. Set up your virtual environment and install requirements:
+1. Ensure you have [Git Large File Storage (LFS)](https://git-lfs.com/)
+   installed:
+
+   ```bash
+   git lfs install
+   ```
+
+2. Set up your virtual environment and install requirements:
 
     ```bash
     python -m venv .venv
@@ -42,7 +49,7 @@ graph LR
         export PATH=path/to/iree-build:$PATH
         ```
 
-2. Run pytest using typical flags:
+3. Run pytest using typical flags:
 
     ```bash
     pytest \
@@ -196,3 +203,9 @@ iree-run-module \
   --input=1x1x28x28xf32=@artifacts/model_zoo/validated/vision/classification/mnist-12_version17_input_0.bin \
   --expected_output=1x10xf32=@artifacts/model_zoo/validated/vision/classification/mnist-12_version17_output_0.bin
 ```
+
+## Caching
+
+Test input files from https://github.com/onnx/models are cached by default at a
+local git checkout stored at `~/.cache/iree-test-suites/onnx_models`. The cache
+location can be changed by passing `--cache-dir=/path/to/cache`.

--- a/onnx_models/cache.py
+++ b/onnx_models/cache.py
@@ -114,8 +114,9 @@ class GitHubLFSRepositoryCacheScope(CacheScope):
     def setup_github_repository(self, repository_name: str, clone_method: str):
         logger.info(f"Setting up GitHub repository '{repository_name}'")
 
-        logger.info("Checking for working 'git lfs' (https://git-lfs.com/)")
-        subprocess.run("git lfs env", capture_output=True, check=True)
+        # Command does not exist on GitHub-hosted Linux runners?
+        # logger.info("Checking for working 'git lfs' (https://git-lfs.com/)")
+        # subprocess.run("git lfs env", capture_output=True, check=True)
 
         # Skip if the directory already exists (and is a git directory).
         if self.local_repository_dir.is_dir():

--- a/onnx_models/cache.py
+++ b/onnx_models/cache.py
@@ -114,15 +114,14 @@ class GitHubLFSRepositoryCacheScope(CacheScope):
     def setup_github_repository(self, repository_name: str, clone_method: str):
         logger.info(f"Setting up GitHub repository '{repository_name}'")
 
-        # Command does not exist on GitHub-hosted Linux runners?
-        # logger.info("Checking for working 'git lfs' (https://git-lfs.com/)")
-        # subprocess.run("git lfs env", capture_output=True, check=True)
+        logger.info("Checking for working 'git lfs' (https://git-lfs.com/)")
+        subprocess.run(["git", "lfs", "env"], capture_output=True, check=True)
 
         # Skip if the directory already exists (and is a git directory).
         if self.local_repository_dir.is_dir():
             logger.info(f"Directory '{self.local_repository_dir}' already exists")
             subprocess.run(
-                "git rev-parse --is-inside-work-tree",
+                ["git", "rev-parse", "--is-inside-work-tree"],
                 cwd=self.local_repository_dir,
                 capture_output=True,
                 check=True,
@@ -136,7 +135,7 @@ class GitHubLFSRepositoryCacheScope(CacheScope):
             remote_url = f"git@github.com:{repository_name}.git"
         logger.info(f"Cloning {remote_url} into '{self.local_repository_dir}'")
         subprocess.run(
-            f"git clone {remote_url} {self.local_repository_dir}", check=True
+            ["git", "clone", remote_url, self.local_repository_dir], check=True
         )
 
     def pull_lfs_file(self, file_relative_path: str):

--- a/onnx_models/cache.py
+++ b/onnx_models/cache.py
@@ -70,14 +70,14 @@ class CacheManager:
         working_subdirectory_file = working_subdirectory / file_name
         logger.debug(f"Symlinking '{working_subdirectory_file}' to '{file_in_cache}'")
         if working_subdirectory_file.is_symlink():
-            if os.path.samefile(str(working_subdirectory_file), str(file_in_cache)):
+            if working_subdirectory_file.samefile(file_in_cache):
                 logger.debug("  Expected symlink already exists")
                 return working_subdirectory_file
-            os.remove(working_subdirectory_file)
+            working_subdirectory_file.unlink()
         elif working_subdirectory_file.exists():
             logger.warning("  Non-symlink file exists. Replacing with a symlink")
-            os.remove(working_subdirectory_file)
-        os.symlink(src=file_in_cache, dst=working_subdirectory_file)
+            working_subdirectory_file.unlink()
+        file_in_cache.symlink_to(working_subdirectory_file)
         return working_subdirectory_file
 
 

--- a/onnx_models/cache.py
+++ b/onnx_models/cache.py
@@ -1,0 +1,167 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import abc
+import logging
+import os
+import subprocess
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+class CacheManager:
+    """Manager class for multiple CacheScope instances.
+
+    Each registered scope can independently manage a set of cached files.
+    Symlinks from the cache are created into a common working directory. For example:
+
+    cache_dir_1/
+      onnx_models/    <--- GitHubLFSRepositoryCacheScope for https://github.com/onnx/models
+        validated/vision/classification/
+          mnist/
+            model/
+              mnist-12.onnx
+          mobilenet/
+            model/
+              mobilenetv2-12.onnx
+      some_other_repository/
+        ...
+
+    cache_dir_2/
+      ...
+
+    working_directory/
+      model_zoo/                          <--- scope name
+        validated/vision/classification/  <--- subdirectory
+          mnist-12.mlir                   <--- generated file during a test run
+          mnist-12.onnx                   <--- symlink to cached file
+          mobilenetv2-12.mlir             <--- generated file during a test run
+          mobilenetv2-12.onnx             <--- symlink to cached file
+    """
+
+    def __init__(self, working_directory: Path):
+        self.cache_scopes = []
+        self.working_directory = working_directory
+
+    def get_file_in_cache(self, scope_name: str, relative_path: str) -> Path:
+        """Gets the path to a file in the cache, if it exists"""
+        logger.info(f"Getting file from {scope_name} cache: {relative_path}")
+        for cache_scope in self.cache_scopes:
+            if cache_scope.scope_name == scope_name:
+                return cache_scope.get_file(relative_path)
+        raise ValueError(f"Unknown cache scope: '{cache_scope}'")
+
+    def get_file_in_working_directory(
+        self, scope_name: str, relative_path: str, subdirectory: str
+    ) -> Path:
+        """Gets the path to a file from the cache, symlinked into the working directory"""
+        file_in_cache = self.get_file_in_cache(scope_name, relative_path)
+
+        # Create symlink from cache dir to working directory.
+        working_subdirectory = self.working_directory / scope_name / subdirectory
+        logger.debug(f"Working subdirectory: {working_subdirectory}")
+        working_subdirectory.mkdir(parents=True, exist_ok=True)
+
+        file_name = relative_path.rsplit("/", 1)[-1]
+        working_subdirectory_file = working_subdirectory / file_name
+        logger.debug(f"Symlinking '{working_subdirectory_file}' to '{file_in_cache}'")
+        if working_subdirectory_file.is_symlink():
+            if os.path.samefile(str(working_subdirectory_file), str(file_in_cache)):
+                logger.debug("  Expected symlink already exists")
+                return working_subdirectory_file
+            os.remove(working_subdirectory_file)
+        elif working_subdirectory_file.exists():
+            logger.warning("  Non-symlink file exists. Replacing with a symlink")
+            os.remove(working_subdirectory_file)
+        os.symlink(src=file_in_cache, dst=working_subdirectory_file)
+        return working_subdirectory_file
+
+
+class CacheScope(abc.ABC):
+    """Abstract base class for a cache scope."""
+
+    def __init__(self, scope_name: str):
+        self.scope_name = scope_name
+
+    @abc.abstractmethod
+    def get_file(self, relative_path: str) -> Path:
+        """Get the path to a file loaded from the cache"""
+
+
+class GitHubLFSRepositoryCacheScope(CacheScope):
+    """Cache scope backed by a GitHub repository using Git LFS for files of interest."""
+
+    def __init__(
+        self,
+        scope_name: str,
+        cache_dir: Path,
+        repository_name: str,
+        clone_method: str = "https",
+    ):
+        super().__init__(scope_name)
+
+        self.repository_name = repository_name
+        self.local_repository_dir = cache_dir / repository_name.replace("/", "_")
+
+        self.setup_github_repository(
+            repository_name=repository_name, clone_method=clone_method
+        )
+
+    def setup_github_repository(self, repository_name: str, clone_method: str):
+        logger.info(f"Setting up GitHub repository '{repository_name}'")
+
+        logger.info("Checking for working 'git lfs' (https://git-lfs.com/)")
+        subprocess.run("git lfs env", capture_output=True, check=True)
+
+        # Skip if the directory already exists (and is a git directory).
+        if self.local_repository_dir.is_dir():
+            logger.info(f"Directory '{self.local_repository_dir}' already exists")
+            subprocess.run(
+                "git rev-parse --is-inside-work-tree",
+                cwd=self.local_repository_dir,
+                capture_output=True,
+                check=True,
+            )
+            return
+
+        # Directory does not exist yet, clone.
+        if clone_method == "https":
+            remote_url = f"https://github.com/{repository_name}.git"
+        else:
+            remote_url = f"git@github.com:{repository_name}.git"
+        logger.info(f"Cloning {remote_url} into '{self.local_repository_dir}'")
+        subprocess.run(
+            f"git clone {remote_url} {self.local_repository_dir}", check=True
+        )
+
+    def pull_lfs_file(self, file_relative_path: str):
+        logger.debug(
+            f"Pulling git LFS file '{self.local_repository_dir / file_relative_path}'"
+        )
+        command = [
+            "git",
+            "lfs",
+            "pull",
+            f"--include={file_relative_path}",
+            '--exclude=""',
+        ]
+        logger.debug(
+            f"Running command:\n  cd {self.local_repository_dir}\n  {subprocess.list2cmdline(command)}"
+        )
+        subprocess.run(command, check=True, cwd=self.local_repository_dir)
+
+    def get_file(self, relative_path: str) -> Path:
+        # Log file information for easier reproduction outside of the test suite.
+        direct_download_url = (
+            f"https://github.com/{self.repository_name}/raw/main/{relative_path}"
+        )
+        logger.info(
+            f"Getting file '{relative_path}' from cache. Direct download URL:\n  {direct_download_url}"
+        )
+
+        self.pull_lfs_file(relative_path)
+        return self.local_repository_dir / relative_path

--- a/onnx_models/cache.py
+++ b/onnx_models/cache.py
@@ -6,7 +6,6 @@
 
 import abc
 import logging
-import os
 import subprocess
 from pathlib import Path
 
@@ -77,7 +76,7 @@ class CacheManager:
         elif working_subdirectory_file.exists():
             logger.warning("  Non-symlink file exists. Replacing with a symlink")
             working_subdirectory_file.unlink()
-        file_in_cache.symlink_to(working_subdirectory_file)
+        working_subdirectory_file.symlink_to(file_in_cache)
         return working_subdirectory_file
 
 

--- a/onnx_models/conftest.py
+++ b/onnx_models/conftest.py
@@ -102,7 +102,7 @@ def pytest_sessionstart(session):
         cache_dir=cache_dir,
         repository_name="onnx/models",
     )
-    cache_manager.cache_scopes.append(onnx_models_cache)
+    cache_manager.register_scope(onnx_models_cache)
     session.config.cache_manager = cache_manager
 
 

--- a/onnx_models/conftest.py
+++ b/onnx_models/conftest.py
@@ -71,11 +71,16 @@ def pytest_addoption(parser):
         help="Config JSON file used to parameterize test cases",
     )
 
+    env_path_root = os.getenv("IREE_TEST_FILES")
+    if env_path_root:
+        default_cache_dir = Path(env_path_root) / "iree-test-suites"
+    else:
+        default_cache_dir = Path.home() / ".cache" / "iree-test-suites"
     parser.addoption(
         "--cache-dir",
         type=Path,
-        default=Path.home() / ".cache" / "iree-test-suites",
-        help="Cache directory to store files at. Defaults to ~/.cache/iree-test-suites",
+        default=default_cache_dir,
+        help="Cache directory to store files at. Defaults to ${IREE_TEST_FILES}/iree-test-suites if IREE_TEST_FILES is set, or ~/.cache/iree-test-suites",
     )
 
 

--- a/onnx_models/tests/model_zoo/validated/vision/body_analysis_models_test.py
+++ b/onnx_models/tests/model_zoo/validated/vision/body_analysis_models_test.py
@@ -10,8 +10,7 @@ import pytest
 
 from .....utils import *
 
-ARTIFACTS_SUBDIR = "model_zoo/validated/vision/body_analysis"
-BASE_URL = "https://github.com/onnx/models/raw/main/validated/vision/body_analysis/"
+BASE_PATH = "validated/vision/body_analysis/"
 
 
 @pytest.mark.parametrize(
@@ -29,5 +28,5 @@ BASE_URL = "https://github.com/onnx/models/raw/main/validated/vision/body_analys
 )
 def test_models(compare_between_iree_and_onnxruntime, model):
     compare_between_iree_and_onnxruntime(
-        model_url=BASE_URL + model, artifacts_subdir=ARTIFACTS_SUBDIR
+        model_url=BASE_PATH + model, artifacts_subdir=BASE_PATH
     )

--- a/onnx_models/tests/model_zoo/validated/vision/classification_models_test.py
+++ b/onnx_models/tests/model_zoo/validated/vision/classification_models_test.py
@@ -10,8 +10,7 @@ import pytest
 
 from .....utils import *
 
-ARTIFACTS_SUBDIR = "model_zoo/validated/vision/classification"
-BASE_URL = "https://github.com/onnx/models/raw/main/validated/vision/classification/"
+BASE_PATH = "validated/vision/classification/"
 
 
 @pytest.mark.parametrize(
@@ -40,5 +39,6 @@ BASE_URL = "https://github.com/onnx/models/raw/main/validated/vision/classificat
 )
 def test_models(compare_between_iree_and_onnxruntime, model):
     compare_between_iree_and_onnxruntime(
-        model_url=BASE_URL + model, artifacts_subdir=ARTIFACTS_SUBDIR
+        model_url=BASE_PATH + model,
+        artifacts_subdir=BASE_PATH,
     )

--- a/onnx_models/tests/model_zoo/validated/vision/object_detection_segmentation_models_test.py
+++ b/onnx_models/tests/model_zoo/validated/vision/object_detection_segmentation_models_test.py
@@ -10,8 +10,7 @@ import pytest
 
 from .....utils import *
 
-ARTIFACTS_SUBDIR = "model_zoo/validated/vision/object_detection_segmentation"
-BASE_URL = "https://github.com/onnx/models/raw/main/validated/vision/object_detection_segmentation/"
+BASE_PATH = "validated/vision/object_detection_segmentation/"
 
 
 @pytest.mark.parametrize(
@@ -35,5 +34,5 @@ BASE_URL = "https://github.com/onnx/models/raw/main/validated/vision/object_dete
 )
 def test_models(compare_between_iree_and_onnxruntime, model):
     compare_between_iree_and_onnxruntime(
-        model_url=BASE_URL + model, artifacts_subdir=ARTIFACTS_SUBDIR
+        model_url=BASE_PATH + model, artifacts_subdir=BASE_PATH
     )

--- a/onnx_models/tests/model_zoo/validated/vision/style_transfer_models_test.py
+++ b/onnx_models/tests/model_zoo/validated/vision/style_transfer_models_test.py
@@ -10,8 +10,7 @@ import pytest
 
 from .....utils import *
 
-ARTIFACTS_SUBDIR = "model_zoo/validated/vision/style_transfer"
-BASE_URL = "https://github.com/onnx/models/raw/main/validated/vision/style_transfer/"
+BASE_PATH = "validated/vision/style_transfer/"
 
 
 @pytest.mark.parametrize(
@@ -24,5 +23,5 @@ BASE_URL = "https://github.com/onnx/models/raw/main/validated/vision/style_trans
 )
 def test_models(compare_between_iree_and_onnxruntime, model):
     compare_between_iree_and_onnxruntime(
-        model_url=BASE_URL + model, artifacts_subdir=ARTIFACTS_SUBDIR
+        model_url=BASE_PATH + model, artifacts_subdir=BASE_PATH
     )

--- a/onnx_models/tests/model_zoo/validated/vision/super_resolution_models_test.py
+++ b/onnx_models/tests/model_zoo/validated/vision/super_resolution_models_test.py
@@ -10,8 +10,7 @@ import pytest
 
 from .....utils import *
 
-ARTIFACTS_SUBDIR = "model_zoo/validated/vision/super_resolution"
-BASE_URL = "https://github.com/onnx/models/raw/main/validated/vision/super_resolution/"
+BASE_PATH = "validated/vision/super_resolution/"
 
 
 @pytest.mark.parametrize(
@@ -24,5 +23,5 @@ BASE_URL = "https://github.com/onnx/models/raw/main/validated/vision/super_resol
 )
 def test_models(compare_between_iree_and_onnxruntime, model):
     compare_between_iree_and_onnxruntime(
-        model_url=BASE_URL + model, artifacts_subdir=ARTIFACTS_SUBDIR
+        model_url=BASE_PATH + model, artifacts_subdir=BASE_PATH
     )

--- a/onnx_models/utils.py
+++ b/onnx_models/utils.py
@@ -173,7 +173,7 @@ def import_onnx_model_to_mlir(onnx_path: Path) -> Path:
         f"Running import command:\n"  #
         f"  {import_cmd}"
     )
-    ret = subprocess.run(import_cmd, capture_output=True)
+    ret = subprocess.run(import_cmd, shell=True, capture_output=True)
     if ret.returncode != 0:
         logger.error(f"Import of '{onnx_path.name}' failed!")
         logger.error("iree-import-onnx stdout:")

--- a/onnx_models/utils.py
+++ b/onnx_models/utils.py
@@ -158,13 +158,9 @@ def generate_numpy_input_for_ort_node_arg(node_arg: NodeArg):
     raise NotImplementedError(f"Unsupported numpy type: {numpy_type}")
 
 
-# TODO(#18289): use real frontend API, import model in-memory?
 def import_onnx_model_to_mlir(onnx_path: Path) -> Path:
     imported_mlir_path = onnx_path.with_suffix(".mlir")
-    logger.info(
-        f"Importing '{onnx_path.relative_to(THIS_DIR)}' to '{imported_mlir_path.relative_to(THIS_DIR)}'"
-    )
-    exec_args = [
+    import_args = [
         "iree-import-onnx",
         str(onnx_path),
         "--opset-version",
@@ -172,7 +168,12 @@ def import_onnx_model_to_mlir(onnx_path: Path) -> Path:
         "-o",
         str(imported_mlir_path),
     ]
-    ret = subprocess.run(exec_args, capture_output=True)
+    import_cmd = subprocess.list2cmdline(import_args)
+    logger.info(
+        f"Running import command:\n"  #
+        f"  {import_cmd}"
+    )
+    ret = subprocess.run(import_cmd, capture_output=True)
     if ret.returncode != 0:
         logger.error(f"Import of '{onnx_path.name}' failed!")
         logger.error("iree-import-onnx stdout:")


### PR DESCRIPTION
Progress on https://github.com/iree-org/iree-test-suites/issues/6.

This adds a caching layer which allows developers and persistent CI runners to avoid needing to redownload source `.onnx` files.

## Details

* The cache location defaults to `${IREE_TEST_FILES}/iree-test-suites` if `IREE_TEST_FILES` is set, or `~/.cache/iree-test-suites/` otherwise. This can be overridden with the custom `--cache-dir=/path/to/cache` pytest option. Several of our persistent CI machines set the `IREE_TEST_FILES` environment variable already.
* The cache is implemented as a local git clone of the https://github.com/onnx/models repository, which uses [Git Large File Storage (LFS)](https://git-lfs.com/) to store large files. When a file is requested by a test, the cache layer runs `git lfs pull` in the local clone to fetch the latest version of the file and then it creates a symlink from the cache directory to the test working directory. This usage should be pretty similar to what huggingface_hub provides: https://huggingface.co/docs/huggingface_hub/guides/manage-cache.

## Testing

Tested in iree-org/iree on persistent runners here:

* Cold cache: https://github.com/iree-org/iree/actions/runs/12838451019/job/35804050925#step:8:22

    ```
    ---------------------------- live log sessionstart -----------------------------
    INFO     onnx_models.conftest:conftest.py:96 Using cache directory: '/home/esaimana/iree_tests_cache/iree-test-suites'
    INFO     onnx_models.cache:cache.py:115 Setting up GitHub repository 'onnx/models'
    INFO     onnx_models.cache:cache.py:117 Checking for working 'git lfs' (https://git-lfs.com/)
    INFO     onnx_models.cache:cache.py:136 Cloning https://github.com/onnx/models.git into '/home/esaimana/iree_tests_cache/iree-test-suites/onnx_models'
    Cloning into '/home/esaimana/iree_tests_cache/iree-test-suites/onnx_models'...
    ```

* Warm cache: https://github.com/iree-org/iree/actions/runs/12838451019/job/35804127583#step:8:22

    ```
    ---------------------------- live log sessionstart -----------------------------
    INFO     onnx_models.conftest:conftest.py:96 Using cache directory: '/home/esaimana/iree_tests_cache/iree-test-suites'
    INFO     onnx_models.cache:cache.py:115 Setting up GitHub repository 'onnx/models'
    INFO     onnx_models.cache:cache.py:117 Checking for working 'git lfs' (https://git-lfs.com/)
    INFO     onnx_models.cache:cache.py:122 Directory '/home/esaimana/iree_tests_cache/iree-test-suites/onnx_models' already exists
    ```

(The rest of the logs are currently the same)