### PR TITLE
Mark tflite mobilenet test as xfail, pending TOSA v1.0 changes.

### DIFF
--- a/litert_models/tests/kaggle/tensorflow/mobilenet_v1_test.py
+++ b/litert_models/tests/kaggle/tensorflow/mobilenet_v1_test.py
@@ -12,6 +12,7 @@ from ....utils import *
 
 
 # https://www.kaggle.com/models/tensorflow/mobilenet-v1/tfLite/0-25-224
+@pytest.mark.xfail(raises=IreeCompileException)
 def test_mobilenet_v1_0_25_224(tflite_import_and_iree_compile):
     tflite_import_and_iree_compile("tensorflow/mobilenet-v1/tfLite/0-25-224")
 


### PR DESCRIPTION
Newly failing (as expected) after https://github.com/iree-org/iree/pull/19683.