### PR TITLE
Fix mermaidjs markdown rendering for onnx ops diagrams.

### DIFF
--- a/onnx_ops/README.md
+++ b/onnx_ops/README.md
@@ -7,7 +7,7 @@ Testing follows several stages:
 
 ```mermaid
 graph LR
-  Import -. "\n(offline)" .-> Compile
+  Import -. "(offline)" .-> Compile
   Compile --> Run
 ```
 


### PR DESCRIPTION
At some point the `\n` stopped being respected: 
![image](https://github.com/user-attachments/assets/d8a2b9d1-bc4e-4373-8da9-ec6464ed125b)
