### PR TITLE
Fixing Litert Models test to reflect import error

### DIFF
--- a/litert_models/requirements.txt
+++ b/litert_models/requirements.txt
@@ -11,4 +11,4 @@ pytest-xdist
 # ai-edge-litert
 # tflite-runtime
 kagglehub
-tensorflow
+tensorflow<=2.18.0

--- a/litert_models/requirements.txt
+++ b/litert_models/requirements.txt
@@ -11,4 +11,4 @@ pytest-xdist
 # ai-edge-litert
 # tflite-runtime
 kagglehub
-tensorflow<=2.18.0
+tensorflow

--- a/litert_models/tests/kaggle/tensorflow/mobilenet_v1_test.py
+++ b/litert_models/tests/kaggle/tensorflow/mobilenet_v1_test.py
@@ -12,12 +12,12 @@ from ....utils import *
 
 
 # https://www.kaggle.com/models/tensorflow/mobilenet-v1/tfLite/0-25-224
-@pytest.mark.xfail(raises=IreeCompileException)
+@pytest.mark.xfail(raises=IreeImportTfLiteException)
 def test_mobilenet_v1_0_25_224(tflite_import_and_iree_compile):
     tflite_import_and_iree_compile("tensorflow/mobilenet-v1/tfLite/0-25-224")
 
 
 # https://www.kaggle.com/models/tensorflow/mobilenet-v1/tfLite/0-25-224-quantized/
-@pytest.mark.xfail(raises=IreeCompileException)
+@pytest.mark.xfail(raises=IreeImportTfLiteException)
 def test_mobilenet_v1_0_25_224_quantized(tflite_import_and_iree_compile):
     tflite_import_and_iree_compile("tensorflow/mobilenet-v1/tfLite/0-25-224-quantized")


### PR DESCRIPTION
Since tensorflow has released a new version, the tests are currently failing due to an import error. Updating the tests to reflect expected import error and xfail on those tests