### PR TITLE
Llama 8b f16 regression test using random weights and inputs

### DIFF
--- a/sharktank_models/benchmarks/llama/8b_decode_rocm.json
+++ b/sharktank_models/benchmarks/llama/8b_decode_rocm.json
@@ -1,0 +1,21 @@
+{
+    "inputs": [
+        "4x1xi64",
+        "4xi64",
+        "4xi64",
+        "4x5xi64",
+        "34x2097152xf16"
+    ],
+    "function_run": "decode_bs4", 
+    "benchmark_flags": [
+        "--benchmark_repetitions=10",
+        "--benchmark_min_warmup_time=3.0"
+    ],
+    "device": "hip",
+    "golden_time_tolerance_multiplier": {
+        "mi300": 1.1
+    },
+    "golden_time_ms": {
+        "mi300": 15.7
+    }
+}

--- a/sharktank_models/benchmarks/llama/8b_prefill_rocm.json
+++ b/sharktank_models/benchmarks/llama/8b_prefill_rocm.json
@@ -1,0 +1,20 @@
+{
+    "inputs": [
+        "4x128xi64",
+        "4xi64",
+        "4x128xi64",
+        "34x2097152xf16"
+    ],
+    "function_run": "prefill_bs4", 
+    "benchmark_flags": [
+        "--benchmark_repetitions=10",
+        "--benchmark_min_warmup_time=3.0"
+    ],
+    "device": "hip",
+    "golden_time_tolerance_multiplier": {
+        "mi300": 1.1
+    },
+    "golden_time_ms": {
+        "mi300": 43.1
+    }
+}

--- a/sharktank_models/quality_tests/llama/8b_decode_rocm.json
+++ b/sharktank_models/quality_tests/llama/8b_decode_rocm.json
@@ -1,0 +1,33 @@
+{
+    "inputs": [
+        {
+            "source": "https://sharkpublic.blob.core.windows.net/sharkpublic/halo-models/llm-dev/llama3_8b_random/toy_llama_inputs/decode_next_tokens_0.npy"
+        },
+        {
+            "source": "https://sharkpublic.blob.core.windows.net/sharkpublic/halo-models/llm-dev/llama3_8b_random/toy_llama_inputs/decode_seq_lens_0.npy"
+        },
+        {
+            "source": "https://sharkpublic.blob.core.windows.net/sharkpublic/halo-models/llm-dev/llama3_8b_random/toy_llama_inputs/decode_start_positions_0.npy"
+        },
+        {
+            "source": "https://sharkpublic.blob.core.windows.net/sharkpublic/halo-models/llm-dev/llama3_8b_random/toy_llama_inputs/decode_seq_block_ids_0.npy"
+        },
+        {
+            "source": "https://sharkpublic.blob.core.windows.net/sharkpublic/halo-models/llm-dev/llama3_8b_random/toy_llama_inputs/decode_cache_state_0.npy"
+        }
+    ],
+    "device": "hip",
+    "real_weights": "https://sharkpublic.blob.core.windows.net/sharkpublic/halo-models/llm-dev/llama3_8b_random/8b_f16_random.irpa",
+    "mlir": "https://sharkpublic.blob.core.windows.net/sharkpublic/halo-models/llm-dev/llama3_8b_random/8b_f16_random.mlir",
+    "compiler_flags": [
+        "--iree-hip-target=gfx942",
+        "--iree-hal-target-device=hip",
+        "--iree-opt-level=O3",
+        "--iree-hal-indirect-command-buffers=true",
+        "--iree-stream-resource-memory-model=discrete",
+        "--iree-hal-memoization=true",
+        "--iree-scheduling-dump-statistics-format=json",
+        "--iree-scheduling-dump-statistics-file=compilation_info.json"
+    ],
+    "run_function": "decode_bs4"
+}

--- a/sharktank_models/quality_tests/llama/8b_prefill_rocm.json
+++ b/sharktank_models/quality_tests/llama/8b_prefill_rocm.json
@@ -1,0 +1,30 @@
+{
+    "inputs": [
+        {
+            "source": "https://sharkpublic.blob.core.windows.net/sharkpublic/halo-models/llm-dev/llama3_8b_random/toy_llama_inputs/prefill_token_ids.npy",
+        },
+        {
+            "source": "https://sharkpublic.blob.core.windows.net/sharkpublic/halo-models/llm-dev/llama3_8b_random/toy_llama_inputs/prefill_seq_lens.npy",
+        },
+        {
+            "source": "https://sharkpublic.blob.core.windows.net/sharkpublic/halo-models/llm-dev/llama3_8b_random/toy_llama_inputs/prefill_seq_block_ids.npy",
+        },
+        {
+            "source": "https://sharkpublic.blob.core.windows.net/sharkpublic/halo-models/llm-dev/llama3_8b_random/toy_llama_inputs/prefill_cache_state.npy",
+        }
+    ],
+    "device": "hip",
+    "real_weights": "https://sharkpublic.blob.core.windows.net/sharkpublic/halo-models/llm-dev/llama3_8b_random/8b_f16_random.irpa",
+    "mlir": "https://sharkpublic.blob.core.windows.net/sharkpublic/halo-models/llm-dev/llama3_8b_random/8b_f16_random.mlir",
+    "compiler_flags": [
+        "--iree-hip-target=gfx942",
+        "--iree-hal-target-device=hip",
+        "--iree-opt-level=O3",
+        "--iree-hal-indirect-command-buffers=true",
+        "--iree-stream-resource-memory-model=discrete",
+        "--iree-hal-memoization=true",
+        "--iree-scheduling-dump-statistics-format=json",
+        "--iree-scheduling-dump-statistics-file=compilation_info.json"
+    ],
+    "run_function": "prefill_bs4"
+}

--- a/sharktank_models/quality_tests/llama/8b_prefill_rocm.json
+++ b/sharktank_models/quality_tests/llama/8b_prefill_rocm.json
@@ -1,16 +1,16 @@
 {
     "inputs": [
         {
-            "source": "https://sharkpublic.blob.core.windows.net/sharkpublic/halo-models/llm-dev/llama3_8b_random/toy_llama_inputs/prefill_token_ids.npy",
+            "source": "https://sharkpublic.blob.core.windows.net/sharkpublic/halo-models/llm-dev/llama3_8b_random/toy_llama_inputs/prefill_token_ids.npy"
         },
         {
-            "source": "https://sharkpublic.blob.core.windows.net/sharkpublic/halo-models/llm-dev/llama3_8b_random/toy_llama_inputs/prefill_seq_lens.npy",
+            "source": "https://sharkpublic.blob.core.windows.net/sharkpublic/halo-models/llm-dev/llama3_8b_random/toy_llama_inputs/prefill_seq_lens.npy"
         },
         {
-            "source": "https://sharkpublic.blob.core.windows.net/sharkpublic/halo-models/llm-dev/llama3_8b_random/toy_llama_inputs/prefill_seq_block_ids.npy",
+            "source": "https://sharkpublic.blob.core.windows.net/sharkpublic/halo-models/llm-dev/llama3_8b_random/toy_llama_inputs/prefill_seq_block_ids.npy"
         },
         {
-            "source": "https://sharkpublic.blob.core.windows.net/sharkpublic/halo-models/llm-dev/llama3_8b_random/toy_llama_inputs/prefill_cache_state.npy",
+            "source": "https://sharkpublic.blob.core.windows.net/sharkpublic/halo-models/llm-dev/llama3_8b_random/toy_llama_inputs/prefill_cache_state.npy"
         }
     ],
     "device": "hip",


### PR DESCRIPTION
This PR adds regression tests for llama 8b f16 prefill and decode using randomized llama 8b f16 weights and inputs. We use random llama 8b f16 weights in order to download a public version of the weights (the original weights are gated and require access from the model authors from the huggingface repo).