### PR TITLE
Add _initrequest for pytest-retry to avoid AttributeError for sharktank tests

### DIFF
--- a/sharktank_models/benchmarks/model_benchmark_run.py
+++ b/sharktank_models/benchmarks/model_benchmark_run.py
@@ -307,3 +307,7 @@ class ModelBenchmarkRunItem(pytest.Item):
 
     def reportinfo(self):
         return self.path, 0, f"usecase: {self.name}"
+
+    # Defining this for pytest-retry to avoid an AttributeError.
+    def _initrequest(self):
+        pass


### PR DESCRIPTION
Add _initrequest for pytest-retry to avoid AttributeError for sharktank tests. Sometimes the CI fails with an AttributeError:
```
INTERNALERROR> AttributeError: 'ModelBenchmarkRunItem' object has no attribute '_initrequest'
---------------------------- live log sessionfinish ----------------------------
INFO     conftest:conftest.py:99 Pytest benchmark test session has finished
```