### PR TITLE
[NFC] Update example commands and fix typos.

### DIFF
--- a/sharktank_models/README.md
+++ b/sharktank_models/README.md
@@ -13,20 +13,18 @@ built as part of the [shark-ai project](https://github.com/nod-ai/shark-ai).
     git lfs install
     git lfs pull --include="*"
 
-     git lfs ls-files
-     # 37f90b4754 * sharktank_models/llama3.1/assets/toy_llama.irpa
-     # 7172acdf43 * sharktank_models/llama3.1/assets/toy_llama.mlir
-     # e997647ecc * sharktank_models/llama3.1/assets/toy_llama_tp2.irpa
-     # b7b2f5a206 * sharktank_models/llama3.1/assets/toy_llama_tp2.mlir
-     # 917845c887 * sharktank_models/llama3.1/assets/toy_llama_tp2.rank0.irpa
-     # 9ab51093c4 * sharktank_models/llama3.1/assets/toy_llama_tp2.rank1.irpa
-     ```
+    git lfs ls-files
+    # 37f90b4754 * sharktank_models/llama3.1/assets/toy_llama.irpa
+    # 7172acdf43 * sharktank_models/llama3.1/assets/toy_llama.mlir
+    # e997647ecc * sharktank_models/llama3.1/assets/toy_llama_tp2.irpa
+    # b7b2f5a206 * sharktank_models/llama3.1/assets/toy_llama_tp2.mlir
+    # 917845c887 * sharktank_models/llama3.1/assets/toy_llama_tp2.rank0.irpa
+    # 9ab51093c4 * sharktank_models/llama3.1/assets/toy_llama_tp2.rank1.irpa
+    ```
 
 2. Set up your virtual environment and install requirements:
 
     ```bash
-    cd sharktank_models
-
     python -m venv .venv
     source .venv/bin/activate
     python -m pip install -e sharktank_models/
@@ -100,19 +98,19 @@ built as part of the [shark-ai project](https://github.com/nod-ai/shark-ai).
 
 ## Running quality tests
 
-Please refer to [Quality tests README](quality_tests/README.md) to run tests
+Please refer to [Quality tests README](quality_tests/README.md) to run tests.
 
 ## Running benchmark tests
 
-Please refer to [Benchmark tests README](benchmarks/README.md) to run tests
+Please refer to [Benchmark tests README](benchmarks/README.md) to run tests.
 
-Note: for benchmark tests to run, you will need `vmfbs` files available
+Note: for benchmark tests to run, you will need `vmfbs` files available.
 
 ## Generating model files using Shark AI
 
-In order to generate and compile MLIR files to compile, run quality tests and benchmarking tests, please run the following the following commands:
+In order to generate and compile MLIR files to compile, run quality tests and benchmarking tests, please run the following commands:
 
-This example generates IRPA and MLIR files for Llama, please look in [Shark AI Models](https://github.com/nod-ai/shark-ai/tree/main/sharktank/sharktank/models) to see which models you can generate
+This example generates IRPA and MLIR files for Llama, please look in [Shark AI Models](https://github.com/nod-ai/shark-ai/tree/main/sharktank/sharktank/models) to see which models you can generate.
 
 ```
 python3 -m pip install sharktank

--- a/sharktank_models/quality_tests/README.md
+++ b/sharktank_models/quality_tests/README.md
@@ -2,13 +2,13 @@
 
 ### Adding your own model
 
-- To add your own model, create a directory under `quality_tests` and add JSON files that correspond to the submodels. Please follow the [JSON file schema in this README file](#required-and-optional-fields-for-the-json-model-file)
+- To add your own model, create a directory under `quality_tests` and add JSON files that correspond to the submodels. Please follow the [JSON file schema in this README file](#required-and-optional-fields-for-the-json-model-file).
 
-- Please refer to the sample file `sdxl/clip_rocm.json`
+- Please refer to the sample file `sdxl/clip_rocm.json`.
 
 ### How to run
 
-- Command to run quality tests for a specific model
+- Command to run quality tests for a specific model:
 
 ```
 # Retrieving test files and external test files
@@ -16,7 +16,7 @@ git clone https://github.com/iree-org/iree.git
 export PATH_TO_TESTS=iree/tests/external/iree-test-suites/sharktank_models/quality_tests
 export PATH_TO_EXTERNAL_FILES=iree/build_tools/pkgci/external_test_suite
 
-# running quality tests
+# Running quality tests
 git clone https://github.com/iree-org/iree-test-suites.git
 pytest iree-test-suites/sharktank_models/quality_tests/ \
     -rpFe \
@@ -48,4 +48,4 @@ pytest iree-test-suites/sharktank_models/quality_tests/ \
 | tuner_file                     | optional | dict    | Adds a `iree-codegen-transform-dialect-library` compiler flag for a SKU-specific tuner file (ex: `{"mi308": "{tuner_file_name}"}`)               |
 | custom_real_weights_group      | optional | string  | Add a custom group to a weights source retrieval                                                                                                 |
 
-Please feel free to look at any JSON examples under a model directory (ex: sd3, sdxl)
+Please feel free to look at any JSON examples under a model directory (ex: sd3, sdxl).


### PR DESCRIPTION
- Remove `cd sharktank_models` from the setup because other commands assume users being at the root directory.
- Add missing periods at the end.
- Remove unnecessary whitespace from `git lfs`.
- Make style more consistent.