### PR TITLE
Increase golden time for clip_cpu

### DIFF
--- a/torch_models/examples/clip_cpu_benchmark.json
+++ b/torch_models/examples/clip_cpu_benchmark.json
@@ -32,5 +32,5 @@
       "--function=encode_prompts",
       "--device_allocator=caching"
     ],
-    "golden_time_ms": 3865.0
+    "golden_time_ms": 40000.0
 }


### PR DESCRIPTION
This is a follow-up to https://github.com/iree-org/iree/pull/22159 where the golden time wasn't increased enough. 