### PR TITLE
Golden time update for clip CPU

### DIFF
--- a/sharktank_models/benchmarks/sdxl/clip_cpu.json
+++ b/sharktank_models/benchmarks/sdxl/clip_cpu.json
@@ -16,7 +16,7 @@
         "cpu": 1.1
     },
     "golden_time_ms": {
-        "cpu": 2850.0
+        "cpu": 40000.0
     },
     "golden_dispatch": {
         "cpu": 2100

--- a/torch_models/examples/clip_cpu_benchmark.json
+++ b/torch_models/examples/clip_cpu_benchmark.json
@@ -32,5 +32,5 @@
       "--function=encode_prompts",
       "--device_allocator=caching"
     ],
-    "golden_time_ms": 40000.0
+    "golden_time_ms": 2850.0
 }


### PR DESCRIPTION

First change was https://github.com/iree-org/iree-test-suites/commit/3b0628c55b059361a9b9dd85c133c74cf0ae9416
Second change was https://github.com/iree-org/iree-test-suites/commit/a8e9673a60ca9f324e030c980d41194a61bf3885

Current failure I see is 

INFO     model_benchmark_run:model_benchmark_run.py:226 sdxl clip benchmark time: 38922.793748500015 ms (golden time 2850.0 ms)

See https://github.com/iree-org/iree-test-suites/actions/runs/18317198606/job/52160587711

Searching for '2850' (the golden time the test is still failing) with I found it in a different file. Did the first 2 changes change the wrong value? Bumping this golden value and returning the pytorch one to its original value. 