### PR TITLE
[torch_models] Change module caching behavior

### DIFF
--- a/.github/workflows/test_torch_models.yml
+++ b/.github/workflows/test_torch_models.yml
@@ -71,7 +71,6 @@ jobs:
             --module-directory=torch_models \
             --artifact-directory=${{ github.workspace }}/torch_models_artifacts \
             --job-summary-path=${{ github.workspace }} \
-            --force-recompile \
             -m "quick or compstat"
 
       - name: Upload Torch Model Job Summary

--- a/torch_models/README.md
+++ b/torch_models/README.md
@@ -87,7 +87,7 @@ pytest torch_modles \
     --log-cli-level=info
 ```
 
-- Force recompilation of modules even if modules are cached from a previous run:
+- Cache all module compilation between different runs.
 
 ```bash
 pytest \
@@ -96,7 +96,7 @@ pytest \
     --external-file-directory=./ \
     --log-cli-level=info \
     -m "hip or cpu" \
-    --force-recompile
+    --cache-modules
 ```
 
 ### pytest-iree Flags
@@ -110,18 +110,18 @@ pytest \
 
 - `--artifact-directory`: The directory to store any artifacts (e.g. compiled
   modules). Defaults to `./artifacts` in the current working directory.
-- `--force-recompile`: If set, forces recompilation of modules even if a cached
-  compiled module already exists. Defaults to False. Useful for testing
-  compiler changes.
+- `--cache-modules`: If set, caches modules between different test runs. This
+  is useful when writing and debugging test cases.
 
 ## Tips
 
-- By default, the plugin caches all compiled modules and downloaded artifacts.
-  If you are doing compiler development, you always want to set the
-  `--force-recompile` flag. If you are building tests, but not modifying module
-  definitions, you should keep it on to not have compilation overhead.
-- The caching of modules and downloaded artifacts is predictable. Look at the
-  artifact class definition to find out how the particular artifact is cached.
+- By default, the plugin does not cache compiled modules. If you are building
+  tests, but not modifying module definitions, you should keep it on to not
+  have compilation overhead.
+- The caching of (artifacts modules, downloaded artifacts, generated irpas) is
+  predictable. Look at the artifact class definition to find out how the
+  particular artifact is cached. You can manually modify the artifact cache
+  as long as you follow the caching behavior.
 - Every iree command is ran with "external-file-directory" as the cwd. So if
   you have any relative paths in your module definitions or test definitions,
   they are relative to that directory.

--- a/torch_models/pytest_iree/benchmark_test.py
+++ b/torch_models/pytest_iree/benchmark_test.py
@@ -20,8 +20,10 @@ class IREEBenchmarkTest(TestBase):
     A test case for benchmarking IREE modules for given input data.
     """
 
-    def __init__(self, *, test_data: dict, **kwargs):
-        super().__init__(test_data=test_data, **kwargs)
+    def __init__(self, *, test_data: dict, temp_working_dir: Path, **kwargs):
+        super().__init__(
+            test_data=test_data, temp_working_dir=temp_working_dir, **kwargs
+        )
         self.add_marker("benchmark")
         self.golden_time = test_data.get("golden_time_ms", None)
         self.module_artifacts = self._get_modules()

--- a/torch_models/pytest_iree/compstat_test.py
+++ b/torch_models/pytest_iree/compstat_test.py
@@ -21,18 +21,14 @@ class IREECompStatTest(TestBase):
     A test case for compilation statistics of IREE modules.
     """
 
-    def __init__(self, *, test_data: dict, **kwargs):
-        super().__init__(test_data=test_data, **kwargs)
+    def __init__(self, *, test_data: dict, temp_working_dir: Path, **kwargs):
+        super().__init__(
+            test_data=test_data, temp_working_dir=temp_working_dir, **kwargs
+        )
         self.add_marker("compstat")
         module = test_data.get("module", None)
         assert module is not None, "Test data must contain 'module' field"
-        self.module_artifact = ModuleArtifact(
-            artifact_base_dir=self.artifact_dir,
-            module_base_dir=self.module_directory,
-            module=module,
-            external_file_dir=self.external_file_directory,
-            force_recompile=self.force_recompile,
-        )
+        self.module_artifact = self._get_module(module)
         self.golden_dispatch_count = test_data.get("golden_dispatch_count", None)
         self.golden_binary_size = test_data.get("golden_binary_size", None)
         self.current_dispatch_count = None

--- a/torch_models/pytest_iree/module.py
+++ b/torch_models/pytest_iree/module.py
@@ -14,8 +14,8 @@ class ModuleArtifact(Artifact):
     artifact's uniqueness is defined by it's module name. The module definition
     can be found at `<module_base_dir>/Path(<module>).json`.
 
-    The artifact creates a directory structure under the artifact_base_dir as:
-    artifact_base_dir/
+    The artifact creates a directory structure under the module_artifact_base_dir as:
+    module_artifact_base_dir/
         modules/
             <module1>/
                 <module1>.vmfb
@@ -27,26 +27,17 @@ class ModuleArtifact(Artifact):
     def __init__(
         self,
         artifact_base_dir: Path,
+        module_artifact_base_dir: Path,
         module_base_dir: Path,
         module: str,
         external_file_dir: Path,
-        force_recompile: bool = False,
     ):
-        artifact_dir = artifact_base_dir / "modules"
-        module_artifact_dir = artifact_dir / Path(module)
+        module_artifact_dir = module_artifact_base_dir / "modules" / Path(module)
         name = "module.vmfb"
         module_json = (module_base_dir / Path(module)).with_suffix(".json")
         assert (
             module_json.exists()
         ), f"Module definition '{module_json}' does not exist."
-
-        # Delete the directory to force recompilation of module if requested.
-        if force_recompile and module_artifact_dir.exists():
-            logger.info(
-                f"  Force recompilation - removing existing module artifact directory '{module_artifact_dir}'"
-            )
-            shutil.rmtree(module_artifact_dir)
-
         super().__init__(module_artifact_dir, name)
 
         self.artifact_base_dir = artifact_base_dir

--- a/torch_models/pytest_iree/quality_test.py
+++ b/torch_models/pytest_iree/quality_test.py
@@ -20,8 +20,10 @@ class IREEQualityTest(TestBase):
     A test case for accuracy quality of IREE modules, for given input data.
     """
 
-    def __init__(self, *, test_data: dict, **kwargs):
-        super().__init__(test_data=test_data, **kwargs)
+    def __init__(self, *, test_data: dict, temp_working_dir: Path, **kwargs):
+        super().__init__(
+            test_data=test_data, temp_working_dir=temp_working_dir, **kwargs
+        )
         self.add_marker("quality")
         self.module_artifacts = self._get_modules()
         self.weight_artifacts = self._get_weights()


### PR DESCRIPTION
Before this patch, compiled modules were being cached by default and the force recompile feature simply deleted this cached directory. The problem with this behavior is multiple runners sharing the cache directory can conflict with each other's modules if they are not caching modules.

This patch makes them create a temporary working directory inside the artifact directory (can also change it to a user passed flag in future) and cache modules for the run during that.

This patch also flips the original "force-recompile" flag, and adding a "cache-modules" flag, which caches the modules between different runs.