### PR TITLE
Allow using MLIR files checked into the repo (using git-lfs)

### DIFF
--- a/torch_models/examples/modules/clip_cpu.json
+++ b/torch_models/examples/modules/clip_cpu.json
@@ -1,4 +1,5 @@
 {
+  "type" : "azure",
   "mlir": "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-prompt-encoder/model.mlir",
     "compiler_flags": [
         "--iree-hal-local-target-device-backends=llvm-cpu",

--- a/torch_models/examples/modules/scheduled_unet_cpu.json
+++ b/torch_models/examples/modules/scheduled_unet_cpu.json
@@ -1,4 +1,5 @@
 {
+  "type": "azure",
   "mlir": "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-scheduled-unet/model.mlir",
   "compiler_flags": [
       "--iree-hal-target-device=local",

--- a/torch_models/examples/modules/scheduler_cpu.json
+++ b/torch_models/examples/modules/scheduler_cpu.json
@@ -1,4 +1,5 @@
 {
+  "type": "azure",
   "mlir": "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-scheduled-unet/sdxl_unet_pipeline_bench_f16.mlir",
   "compiler_flags": [
     "--iree-hal-target-device=local",

--- a/torch_models/examples/modules/scheduler_gfx1201.json
+++ b/torch_models/examples/modules/scheduler_gfx1201.json
@@ -1,4 +1,5 @@
 {
+  "type": "azure",
   "mlir": "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-scheduled-unet/sdxl_unet_pipeline_bench_f16.mlir",
   "compiler_flags": [
       "--iree-hal-target-device=hip",

--- a/torch_models/pytest_iree/git_lfs.py
+++ b/torch_models/pytest_iree/git_lfs.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+import logging
+import subprocess
+from pytest_iree.artifact import Artifact
+
+logger = logging.getLogger(__name__)
+
+class GitLfsArtifact(Artifact):
+    """
+    Represents an artifact that is stored in the repo using git lfs.
+    """
+
+    def __init__(
+            self,
+            module_base_dir: Path,
+            filename: str,
+    ):
+        super().__init__(module_base_dir, filename)
+
+    def pull_lfs_file(self):
+        if (self.path.exists()):
+            return
+        
+        logger.info(f"  Pulling git LFS file '{self.path}'")
+        command = [
+            "git", "lfs", "pull", f"--include={self.name}", '--exclude""']
+        logger.debug(f"  Running command: \n  cd {self.module_path}\n  {subprocess.list2cmdline(command)}")
+        subprocess.run(command, check=True, cwd=self.artifact_dir)
+
+    def join(self):
+        super().join()
+        self.pull_lfs_file()
+    
+


### PR DESCRIPTION
This change is to allow using MLIR files that are checked into the repository using GIT LFS. To support this adding a new "type" field to the compilation modules JSON that says how to get the MLIR.