### PR TITLE
Add numpy to requirements to pytorch ops tests

### DIFF
--- a/pytorch_ops/requirements.txt
+++ b/pytorch_ops/requirements.txt
@@ -2,10 +2,10 @@
 #   * See requirements-iree.txt for using IREE packages.
 #   * See requirements-dev.txt for extra deps used to regenerate test cases.
 
+numpy
 pyjson5
 pytest
 pytest-html
 pytest-reportlog
 pytest-timeout
 pytest-xdist
-numpy


### PR DESCRIPTION
`numpy` was missing from the requirements for pytorch ops tests. Needed to run successfully on CI. Successful run targeting this branch can be seen here: https://github.com/iree-org/iree/actions/runs/19075281868/job/54489810141