### PR TITLE
[torch_models] Turn off git-lfs for torch models

### DIFF
--- a/.github/workflows/test_torch_models.yml
+++ b/.github/workflows/test_torch_models.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          lfs: true
+          lfs: false
 
       # Install Python packages.
       - name: Setup Python


### PR DESCRIPTION
git-lfs appears not to be used in torch models. Further supported by a comment on the [IREE github action file: ](https://github.com/iree-org/iree/blob/main/.github/workflows/pkgci_test_torch.yml#L150-L151)

>           # Don't need lfs for torch models yet.
>          lfs: false
