### PR TITLE
Update sharkpublic to amdsharkpublic.

### DIFF
--- a/sharktank_models/ireers_tools/artifacts.py
+++ b/sharktank_models/ireers_tools/artifacts.py
@@ -164,10 +164,10 @@ class FetchedArtifact(ProducedArtifact):
         # client library for Python (https://pypi.org/project/azure-storage-blob/).
         #
         # For example:
-        #   https://sharkpublic.blob.core.windows.net/sharkpublic/path/to/blob.txt
-        #                                            ^           ^
-        #   account_url:    https://sharkpublic.blob.core.windows.net
-        #   container_name: sharkpublic
+        #   https://amdsharkpublic.blob.core.windows.net/amdsharkpublic/path/to/blob.txt
+        #                                                ^              ^
+        #   account_url:    https://amdsharkpublic.blob.core.windows.net
+        #   container_name: amdsharkpublic
         #   blob_name:      path/to/blob.txt
         result = re.search(r"(https.+\.net)/([^/]+)/(.+)", self.url)
         account_url = result.groups()[0]

--- a/sharktank_models/quality_tests/sdxl/clip_cpu.json
+++ b/sharktank_models/quality_tests/sdxl/clip_cpu.json
@@ -1,35 +1,35 @@
 {
     "inputs": [
         {
-            "source": "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-prompt-encoder/inference_input.0.bin",
+            "source": "https://amdsharkpublic.blob.core.windows.net/amdsharkpublic/sai/sdxl-prompt-encoder/inference_input.0.bin",
             "value": "1x64xi64"
         },
         {
-            "source": "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-prompt-encoder/inference_input.1.bin",
+            "source": "https://amdsharkpublic.blob.core.windows.net/amdsharkpublic/sai/sdxl-prompt-encoder/inference_input.1.bin",
             "value": "1x64xi64"
         },
         {
-            "source": "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-prompt-encoder/inference_input.2.bin",
+            "source": "https://amdsharkpublic.blob.core.windows.net/amdsharkpublic/sai/sdxl-prompt-encoder/inference_input.2.bin",
             "value": "1x64xi64"
         },
         {
-            "source": "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-prompt-encoder/inference_input.3.bin",
+            "source": "https://amdsharkpublic.blob.core.windows.net/amdsharkpublic/sai/sdxl-prompt-encoder/inference_input.3.bin",
             "value": "1x64xi64"
         }
     ],
     "outputs": [
         {
-            "source": "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-prompt-encoder/inference_output.0.bin",
+            "source": "https://amdsharkpublic.blob.core.windows.net/amdsharkpublic/sai/sdxl-prompt-encoder/inference_output.0.bin",
             "value": "2x64x2048xf16"
         },
         {
-            "source": "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-prompt-encoder/inference_output.1.bin",
+            "source": "https://amdsharkpublic.blob.core.windows.net/amdsharkpublic/sai/sdxl-prompt-encoder/inference_output.1.bin",
             "value": "2x1280xf16"
         }
     ],
     "device": "local-task",
-    "real_weights": "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-prompt-encoder/real_weights.irpa",
-    "mlir": "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-prompt-encoder/model.mlir",
+    "real_weights": "https://amdsharkpublic.blob.core.windows.net/amdsharkpublic/sai/sdxl-prompt-encoder/real_weights.irpa",
+    "mlir": "https://amdsharkpublic.blob.core.windows.net/amdsharkpublic/sai/sdxl-prompt-encoder/model.mlir",
     "compiler_flags": [
         "--iree-hal-local-target-device-backends=llvm-cpu",
         "--iree-hal-target-device=local",

--- a/sharktank_models/quality_tests/sdxl/clip_rocm.json
+++ b/sharktank_models/quality_tests/sdxl/clip_rocm.json
@@ -1,35 +1,35 @@
 {
     "inputs": [
         {
-            "source": "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-prompt-encoder/inference_input.0.bin",
+            "source": "https://amdsharkpublic.blob.core.windows.net/amdsharkpublic/sai/sdxl-prompt-encoder/inference_input.0.bin",
             "value": "1x64xi64"
         },
         {
-            "source": "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-prompt-encoder/inference_input.1.bin",
+            "source": "https://amdsharkpublic.blob.core.windows.net/amdsharkpublic/sai/sdxl-prompt-encoder/inference_input.1.bin",
             "value": "1x64xi64"
         },
         {
-            "source": "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-prompt-encoder/inference_input.2.bin",
+            "source": "https://amdsharkpublic.blob.core.windows.net/amdsharkpublic/sai/sdxl-prompt-encoder/inference_input.2.bin",
             "value": "1x64xi64"
         },
         {
-            "source": "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-prompt-encoder/inference_input.3.bin",
+            "source": "https://amdsharkpublic.blob.core.windows.net/amdsharkpublic/sai/sdxl-prompt-encoder/inference_input.3.bin",
             "value": "1x64xi64"
         }
     ],
     "outputs": [
         {
-            "source": "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-prompt-encoder/inference_output.0.bin",
+            "source": "https://amdsharkpublic.blob.core.windows.net/amdsharkpublic/sai/sdxl-prompt-encoder/inference_output.0.bin",
             "value": "2x64x2048xf16"
         },
         {
-            "source": "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-prompt-encoder/inference_output.1.bin",
+            "source": "https://amdsharkpublic.blob.core.windows.net/amdsharkpublic/sai/sdxl-prompt-encoder/inference_output.1.bin",
             "value": "2x1280xf16"
         }
     ],
     "device": "hip",
-    "real_weights": "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-prompt-encoder/real_weights.irpa",
-    "mlir": "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-prompt-encoder/model.mlir",
+    "real_weights": "https://amdsharkpublic.blob.core.windows.net/amdsharkpublic/sai/sdxl-prompt-encoder/real_weights.irpa",
+    "mlir": "https://amdsharkpublic.blob.core.windows.net/amdsharkpublic/sai/sdxl-prompt-encoder/model.mlir",
     "compiler_flags": [
         "--iree-hal-target-backends=rocm",
         "--iree-input-type=torch",

--- a/torch_models/examples/clip_cpu_benchmark.json
+++ b/torch_models/examples/clip_cpu_benchmark.json
@@ -11,7 +11,7 @@
         {
             "type": "url",
             "scope": "model",
-            "url": "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-prompt-encoder/real_weights.irpa"
+            "url": "https://amdsharkpublic.blob.core.windows.net/amdsharkpublic/sai/sdxl-prompt-encoder/real_weights.irpa"
         }
     ],
     "inputs": [

--- a/torch_models/examples/clip_cpu_quality.json
+++ b/torch_models/examples/clip_cpu_quality.json
@@ -11,34 +11,34 @@
         {
             "type": "url",
             "scope": "model",
-            "url": "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-prompt-encoder/real_weights.irpa"
+            "url": "https://amdsharkpublic.blob.core.windows.net/amdsharkpublic/sai/sdxl-prompt-encoder/real_weights.irpa"
         }
     ],
     "inputs": [
         {
-            "url": "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-prompt-encoder/inference_input.0.bin",
+            "url": "https://amdsharkpublic.blob.core.windows.net/amdsharkpublic/sai/sdxl-prompt-encoder/inference_input.0.bin",
             "value": "1x64xi64"
         },
         {
-            "url": "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-prompt-encoder/inference_input.1.bin",
+            "url": "https://amdsharkpublic.blob.core.windows.net/amdsharkpublic/sai/sdxl-prompt-encoder/inference_input.1.bin",
             "value": "1x64xi64"
         },
         {
-            "url": "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-prompt-encoder/inference_input.2.bin",
+            "url": "https://amdsharkpublic.blob.core.windows.net/amdsharkpublic/sai/sdxl-prompt-encoder/inference_input.2.bin",
             "value": "1x64xi64"
         },
         {
-            "url": "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-prompt-encoder/inference_input.3.bin",
+            "url": "https://amdsharkpublic.blob.core.windows.net/amdsharkpublic/sai/sdxl-prompt-encoder/inference_input.3.bin",
             "value": "1x64xi64"
         }
     ],
     "expected_outputs": [
         {
-            "url": "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-prompt-encoder/inference_output.0.bin",
+            "url": "https://amdsharkpublic.blob.core.windows.net/amdsharkpublic/sai/sdxl-prompt-encoder/inference_output.0.bin",
             "value": "2x64x2048xf16"
         },
         {
-            "url": "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-prompt-encoder/inference_output.1.bin",
+            "url": "https://amdsharkpublic.blob.core.windows.net/amdsharkpublic/sai/sdxl-prompt-encoder/inference_output.1.bin",
             "value": "2x1280xf16"
         }
     ],

--- a/torch_models/examples/modules/clip_cpu.json
+++ b/torch_models/examples/modules/clip_cpu.json
@@ -1,5 +1,5 @@
 {
-  "mlir": "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-prompt-encoder/model.mlir",
+  "mlir": "https://amdsharkpublic.blob.core.windows.net/amdsharkpublic/sai/sdxl-prompt-encoder/model.mlir",
   "compiler_flags": [
       "--iree-hal-local-target-device-backends=llvm-cpu",
       "--iree-hal-target-device=local",

--- a/torch_models/examples/modules/scheduled_unet_cpu.json
+++ b/torch_models/examples/modules/scheduled_unet_cpu.json
@@ -1,5 +1,5 @@
 {
-  "mlir": "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-scheduled-unet/model.mlir",
+  "mlir": "https://amdsharkpublic.blob.core.windows.net/amdsharkpublic/sai/sdxl-scheduled-unet/model.mlir",
   "compiler_flags": [
     "--iree-hal-target-device=local",
     "--iree-hal-local-target-device-backends=llvm-cpu",

--- a/torch_models/examples/modules/scheduled_unet_gfx1201.json
+++ b/torch_models/examples/modules/scheduled_unet_gfx1201.json
@@ -1,5 +1,5 @@
 {
-  "mlir": "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-scheduled-unet/model.mlir",
+  "mlir": "https://amdsharkpublic.blob.core.windows.net/amdsharkpublic/sai/sdxl-scheduled-unet/model.mlir",
   "compiler_flags": [
       "--iree-hal-target-device=hip",
       "--iree-hip-target=gfx1201",

--- a/torch_models/examples/modules/scheduler_cpu.json
+++ b/torch_models/examples/modules/scheduler_cpu.json
@@ -1,5 +1,5 @@
 {
-  "mlir": "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-scheduled-unet/sdxl_unet_pipeline_bench_f16.mlir",
+  "mlir": "https://amdsharkpublic.blob.core.windows.net/amdsharkpublic/sai/sdxl-scheduled-unet/sdxl_unet_pipeline_bench_f16.mlir",
   "compiler_flags": [
     "--iree-hal-target-device=local",
     "--iree-hal-local-target-device-backends=llvm-cpu",

--- a/torch_models/examples/modules/scheduler_gfx1201.json
+++ b/torch_models/examples/modules/scheduler_gfx1201.json
@@ -1,5 +1,5 @@
 {
-  "mlir": "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-scheduled-unet/sdxl_unet_pipeline_bench_f16.mlir",
+  "mlir": "https://amdsharkpublic.blob.core.windows.net/amdsharkpublic/sai/sdxl-scheduled-unet/sdxl_unet_pipeline_bench_f16.mlir",
   "compiler_flags": [
       "--iree-hal-target-device=hip",
       "--iree-hip-target=gfx1201",

--- a/torch_models/examples/scheduled_unet_benchmark_cpu.json
+++ b/torch_models/examples/scheduled_unet_benchmark_cpu.json
@@ -9,24 +9,24 @@
         {
             "type": "url",
             "scope": "model",
-            "url": "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-scheduled-unet/real_weights.irpa"
+            "url": "https://amdsharkpublic.blob.core.windows.net/amdsharkpublic/sai/sdxl-scheduled-unet/real_weights.irpa"
         }
     ],
     "inputs": [
         {
-            "url": "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-scheduled-unet/inference_input.0.bin",
+            "url": "https://amdsharkpublic.blob.core.windows.net/amdsharkpublic/sai/sdxl-scheduled-unet/inference_input.0.bin",
             "value": "1x4x128x128xf16"
         },
         {
-            "url": "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-scheduled-unet/inference_input.1.bin",
+            "url": "https://amdsharkpublic.blob.core.windows.net/amdsharkpublic/sai/sdxl-scheduled-unet/inference_input.1.bin",
             "value": "2x64x2048xf16"
         },
         {
-            "url": "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-scheduled-unet/inference_input.2.bin",
+            "url": "https://amdsharkpublic.blob.core.windows.net/amdsharkpublic/sai/sdxl-scheduled-unet/inference_input.2.bin",
             "value": "2x1280xf16"
         },
         {
-            "url": "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-scheduled-unet/inference_input.3.bin",
+            "url": "https://amdsharkpublic.blob.core.windows.net/amdsharkpublic/sai/sdxl-scheduled-unet/inference_input.3.bin",
             "value": "1xf16"
         }
     ],

--- a/torch_models/examples/scheduled_unet_benchmark_gfx1201.json
+++ b/torch_models/examples/scheduled_unet_benchmark_gfx1201.json
@@ -12,24 +12,24 @@
         {
             "type": "url",
             "scope": "model",
-            "url": "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-scheduled-unet/real_weights.irpa"
+            "url": "https://amdsharkpublic.blob.core.windows.net/amdsharkpublic/sai/sdxl-scheduled-unet/real_weights.irpa"
         }
     ],
     "inputs": [
         {
-            "url": "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-scheduled-unet/inference_input.0.bin",
+            "url": "https://amdsharkpublic.blob.core.windows.net/amdsharkpublic/sai/sdxl-scheduled-unet/inference_input.0.bin",
             "value": "1x4x128x128xf16"
         },
         {
-            "url": "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-scheduled-unet/inference_input.1.bin",
+            "url": "https://amdsharkpublic.blob.core.windows.net/amdsharkpublic/sai/sdxl-scheduled-unet/inference_input.1.bin",
             "value": "2x64x2048xf16"
         },
         {
-            "url": "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-scheduled-unet/inference_input.2.bin",
+            "url": "https://amdsharkpublic.blob.core.windows.net/amdsharkpublic/sai/sdxl-scheduled-unet/inference_input.2.bin",
             "value": "2x1280xf16"
         },
         {
-            "url": "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-scheduled-unet/inference_input.3.bin",
+            "url": "https://amdsharkpublic.blob.core.windows.net/amdsharkpublic/sai/sdxl-scheduled-unet/inference_input.3.bin",
             "value": "1xf16"
         }
     ],

--- a/torch_models/examples/scheduled_unet_benchmark_random_gfx1201.json
+++ b/torch_models/examples/scheduled_unet_benchmark_random_gfx1201.json
@@ -19,19 +19,19 @@
     ],
     "inputs": [
         {
-            "url": "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-scheduled-unet/inference_input.0.bin",
+            "url": "https://amdsharkpublic.blob.core.windows.net/amdsharkpublic/sai/sdxl-scheduled-unet/inference_input.0.bin",
             "value": "1x4x128x128xf16"
         },
         {
-            "url": "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-scheduled-unet/inference_input.1.bin",
+            "url": "https://amdsharkpublic.blob.core.windows.net/amdsharkpublic/sai/sdxl-scheduled-unet/inference_input.1.bin",
             "value": "2x64x2048xf16"
         },
         {
-            "url": "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-scheduled-unet/inference_input.2.bin",
+            "url": "https://amdsharkpublic.blob.core.windows.net/amdsharkpublic/sai/sdxl-scheduled-unet/inference_input.2.bin",
             "value": "2x1280xf16"
         },
         {
-            "url": "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-scheduled-unet/inference_input.3.bin",
+            "url": "https://amdsharkpublic.blob.core.windows.net/amdsharkpublic/sai/sdxl-scheduled-unet/inference_input.3.bin",
             "value": "1xf16"
         }
     ],

--- a/torch_models/examples/scheduled_unet_quality_cpu.json
+++ b/torch_models/examples/scheduled_unet_quality_cpu.json
@@ -9,30 +9,30 @@
         {
             "type": "url",
             "scope": "model",
-            "url": "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-scheduled-unet/real_weights.irpa"
+            "url": "https://amdsharkpublic.blob.core.windows.net/amdsharkpublic/sai/sdxl-scheduled-unet/real_weights.irpa"
         }
     ],
     "inputs": [
         {
-            "url": "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-scheduled-unet/inference_input.0.bin",
+            "url": "https://amdsharkpublic.blob.core.windows.net/amdsharkpublic/sai/sdxl-scheduled-unet/inference_input.0.bin",
             "value": "1x4x128x128xf16"
         },
         {
-            "url": "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-scheduled-unet/inference_input.1.bin",
+            "url": "https://amdsharkpublic.blob.core.windows.net/amdsharkpublic/sai/sdxl-scheduled-unet/inference_input.1.bin",
             "value": "2x64x2048xf16"
         },
         {
-            "url": "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-scheduled-unet/inference_input.2.bin",
+            "url": "https://amdsharkpublic.blob.core.windows.net/amdsharkpublic/sai/sdxl-scheduled-unet/inference_input.2.bin",
             "value": "2x1280xf16"
         },
         {
-            "url": "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-scheduled-unet/inference_input.3.bin",
+            "url": "https://amdsharkpublic.blob.core.windows.net/amdsharkpublic/sai/sdxl-scheduled-unet/inference_input.3.bin",
             "value": "1xf16"
         }
     ],
     "expected_outputs": [
         {
-            "url": "https://sharkpublic.blob.core.windows.net/sharkpublic/kunwar/sdxl-scheduler-unet-test-suite-output.npy"
+            "url": "https://amdsharkpublic.blob.core.windows.net/amdsharkpublic/kunwar/sdxl-scheduler-unet-test-suite-output.npy"
         }
     ],
     "run_args": [

--- a/torch_models/examples/scheduled_unet_quality_gfx1201.json
+++ b/torch_models/examples/scheduled_unet_quality_gfx1201.json
@@ -12,30 +12,30 @@
         {
             "type": "url",
             "scope": "model",
-            "url": "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-scheduled-unet/real_weights.irpa"
+            "url": "https://amdsharkpublic.blob.core.windows.net/amdsharkpublic/sai/sdxl-scheduled-unet/real_weights.irpa"
         }
     ],
     "inputs": [
         {
-            "url": "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-scheduled-unet/inference_input.0.bin",
+            "url": "https://amdsharkpublic.blob.core.windows.net/amdsharkpublic/sai/sdxl-scheduled-unet/inference_input.0.bin",
             "value": "1x4x128x128xf16"
         },
         {
-            "url": "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-scheduled-unet/inference_input.1.bin",
+            "url": "https://amdsharkpublic.blob.core.windows.net/amdsharkpublic/sai/sdxl-scheduled-unet/inference_input.1.bin",
             "value": "2x64x2048xf16"
         },
         {
-            "url": "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-scheduled-unet/inference_input.2.bin",
+            "url": "https://amdsharkpublic.blob.core.windows.net/amdsharkpublic/sai/sdxl-scheduled-unet/inference_input.2.bin",
             "value": "2x1280xf16"
         },
         {
-            "url": "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-scheduled-unet/inference_input.3.bin",
+            "url": "https://amdsharkpublic.blob.core.windows.net/amdsharkpublic/sai/sdxl-scheduled-unet/inference_input.3.bin",
             "value": "1xf16"
         }
     ],
     "expected_outputs": [
         {
-            "url": "https://sharkpublic.blob.core.windows.net/sharkpublic/kunwar/sdxl-scheduler-unet-test-suite-output.npy"
+            "url": "https://amdsharkpublic.blob.core.windows.net/amdsharkpublic/kunwar/sdxl-scheduler-unet-test-suite-output.npy"
         }
     ],
     "run_args": [

--- a/torch_models/pytest_iree/azure.py
+++ b/torch_models/pytest_iree/azure.py
@@ -97,10 +97,10 @@ class AzureArtifact(Artifact):
         # client library for Python (https://pypi.org/project/azure-storage-blob/).
         #
         # For example:
-        #   https://sharkpublic.blob.core.windows.net/sharkpublic/path/to/blob.txt
-        #                                            ^           ^
-        #   account_url:    https://sharkpublic.blob.core.windows.net
-        #   container_name: sharkpublic
+        #   https://amdsharkpublic.blob.core.windows.net/amdsharkpublic/path/to/blob.txt
+        #                                                ^              ^
+        #   account_url:    https://amdsharkpublic.blob.core.windows.net
+        #   container_name: amdsharkpublic
         #   blob_name:      path/to/blob.txt
         result = re.search(r"(https.+\.net)/([^/]+)/(.+)", self.url)
         assert result, f"Failed to parse Azure URL '{self.url}'"


### PR DESCRIPTION
amdsharktankpublic is the new account-name and container-name for azure blobs. The files already exist under the new account name and container name so tests should pass.

EDIT: The files exist but are likely not public yet.