### PR TITLE
Remove deleted flag and update golden binary size

### DIFF
--- a/torch_models/examples/modules/scheduled_unet_cpu.json
+++ b/torch_models/examples/modules/scheduled_unet_cpu.json
@@ -5,7 +5,6 @@
     "--iree-hal-local-target-device-backends=llvm-cpu",
     "--iree-llvmcpu-target-cpu-features=host",
     "--iree-opt-level=O3",
-    "--iree-opt-data-tiling",
-    "--iree-global-opt-experimental-disable-conv-generalization"
+    "--iree-opt-data-tiling"
   ]
 }

--- a/torch_models/examples/scheduled_unet_compstat_cpu.json
+++ b/torch_models/examples/scheduled_unet_compstat_cpu.json
@@ -3,5 +3,5 @@
   "markers": ["cpu"],
   "module": "examples/modules/scheduled_unet_cpu",
   "golden_dispatch_count": 2158,
-  "golden_binary_size": 1362295
+  "golden_binary_size": 1541430
 }


### PR DESCRIPTION
* "--iree-global-opt-experimental-disable-conv-generalization" was deleted in https://github.com/iree-org/iree/pull/23377
* updates golden binary size