### PR TITLE
[torch_ops][torch_models] Add tolerance factor multiplier.

### DIFF
--- a/pytest_iree/benchmark_test.py
+++ b/pytest_iree/benchmark_test.py
@@ -27,6 +27,7 @@ class IREEBenchmarkTest(TestBase):
         )
         self.add_marker("benchmark")
         self.golden_time = test_data.get("golden_time_ms", None)
+        self.tolerance_factor = test_data.get("tolerance_factor", 1.1)
         self.module_artifacts = self._get_modules()
         self.weight_artifacts = self._get_weights()
         self.reported_time = None
@@ -59,8 +60,9 @@ class IREEBenchmarkTest(TestBase):
             # https://stackoverflow.com/a/65430875/11660958
             self.reported_time = self._get_min_time_from_output_json(output_json)
             if self.golden_time is not None:
-                assert self.reported_time <= self.golden_time, dedent(
-                    f"""Benchmark failed: reported_time {self.reported_time} exceeds golden_time {self.golden_time}
+                threshold = self.golden_time * self.tolerance_factor
+                assert self.reported_time <= threshold, dedent(
+                    f"""Benchmark failed: reported_time {self.reported_time:.3f} ms exceeds golden_time {self.golden_time:.3f} ms * tolerance_factor {self.tolerance_factor} = {threshold:.3f} ms.
                           Time reported corresponds to the minimum of 10 samples."""
                 )
             self.status = "PASSED"
@@ -74,12 +76,26 @@ class IREEBenchmarkTest(TestBase):
 
     @classmethod
     def get_test_headers(cls) -> list[str]:
-        return ["Name", "Current Time (ms)", "Golden Time (ms)", "Status"]
+        return [
+            "Name",
+            "Current Time (ms)",
+            "Golden Time (ms)",
+            "Tolerance Factor",
+            "Threshold (ms)",
+            "Status",
+        ]
 
     def get_test_summary(self) -> list:
+        if self.golden_time is not None:
+            threshold = self.golden_time * self.tolerance_factor
+            threshold_str = f"{threshold:.3f}"
+        else:
+            threshold_str = "N/A"
         return [
             self.name,
             f"{self.reported_time:.3f}" if self.reported_time is not None else "N/A",
             f"{self.golden_time:.3f}" if self.golden_time is not None else "N/A",
+            f"{self.tolerance_factor}",
+            threshold_str,
             self.status,
         ]

--- a/torch_models/README.md
+++ b/torch_models/README.md
@@ -164,6 +164,7 @@ Please feel free to look at any JSON examples under the `examples` directory for
 | inputs                         | required | argspec | List of inputs to use for this test.                                                                                                             |
 | run_args                       | optional | array   | Additional runtime arguments to pass to the iree-run-module/iree-benchmark-module command.                                                       |
 | golden_time_ms                 | optional | float   | golden time in ms                                                                                                                                |
+| tolerance_factor               | optional | float   | Multiplier applied to golden_time_ms to allow for CI noise. Test passes when `golden_time_ms * tolerance_factor >= reported_time`. Defaults to 1.1 (10% tolerance). |
 ###  Compstat Test Definition
 
 | Field Name                     | Required | Type    | Description                                                                                                                                      |

--- a/torch_ops/README.md
+++ b/torch_ops/README.md
@@ -42,6 +42,7 @@ skip_run_tests: List of tests which run should be skipped.
 expected_compile_failures: List of tests which one expects compilation to fail.
 expected_run_failures: List of tests which one expects run to fail.
 golden_times_ms: Dictionary of tests with golden times in ms.
+tolerance_factor: Multiplier applied to golden_time_ms to allow for CI noise. Test passes when golden_time_ms * tolerance_factor >= reported_time. Defaults to 1.1 (10% tolerance).
 ```
 
 With the generated configuration and the target configuration, one can run any test.

--- a/torch_ops/common.py
+++ b/torch_ops/common.py
@@ -370,7 +370,11 @@ class CommonConfig:
         self.compare_results(self.expected_output, output_files)
 
     def rocprofv3(
-        self, iree_run_flags, golden_time_ms=float("nan"), return_golden_time=False
+        self,
+        iree_run_flags,
+        golden_time_ms=float("nan"),
+        tolerance_factor=1.1,
+        return_golden_time=False,
     ):
         module = self.test_dir / self.vmfb_name
         function = self.function_name
@@ -406,10 +410,18 @@ class CommonConfig:
         real_time_ms = real_time_ns / 1e6
         if return_golden_time:
             return real_time_ms
-        assert real_time_ms <= golden_time_ms
+        threshold = golden_time_ms * tolerance_factor
+        assert real_time_ms <= threshold, (
+            f"Benchmark failed: reported_time {real_time_ms:.3f} ms exceeds "
+            f"golden_time {golden_time_ms:.3f} ms * tolerance_factor {tolerance_factor} = {threshold:.3f} ms."
+        )
 
     def iree_benchmark_module(
-        self, iree_run_flags, golden_time_ms=float("nan"), return_golden_time=False
+        self,
+        iree_run_flags,
+        golden_time_ms=float("nan"),
+        tolerance_factor=1.1,
+        return_golden_time=False,
     ):
         module = self.test_dir / self.vmfb_name
         function = self.function_name
@@ -434,7 +446,11 @@ class CommonConfig:
         real_time_ms = output["benchmarks"][0]["real_time"]
         if return_golden_time:
             return real_time_ms
-        assert real_time_ms <= golden_time_ms
+        threshold = golden_time_ms * tolerance_factor
+        assert real_time_ms <= threshold, (
+            f"Benchmark failed: reported_time {real_time_ms:.3f} ms exceeds "
+            f"golden_time {golden_time_ms:.3f} ms * tolerance_factor {tolerance_factor} = {threshold:.3f} ms."
+        )
 
     def report_golden_time(
         self, iree_compile_flags, iree_run_flags, use_rocprofv3=False
@@ -453,6 +469,7 @@ class CommonConfig:
         iree_compile_flags,
         iree_run_flags,
         golden_time_ms=float("nan"),
+        tolerance_factor=1.1,
         skip_run=False,
         use_rocprofv3=False,
     ):
@@ -469,7 +486,7 @@ class CommonConfig:
                 --input=${self.flat_arg[0]} ... \
                 --output=${output_file}
 
-        assert real_time <= golden_time
+        assert real_time <= golden_time * tolerance_factor
         """
 
         report_time = np.isnan(golden_time_ms) and not skip_run
@@ -486,9 +503,9 @@ class CommonConfig:
             return
 
         if use_rocprofv3:
-            self.rocprofv3(iree_run_flags, golden_time_ms)
+            self.rocprofv3(iree_run_flags, golden_time_ms, tolerance_factor)
             return
-        self.iree_benchmark_module(iree_run_flags, golden_time_ms)
+        self.iree_benchmark_module(iree_run_flags, golden_time_ms, tolerance_factor)
 
     def run_quality_test(self, iree_compile_flags, iree_run_flags, skip_run=False):
         """Run differential test.

--- a/torch_ops/configs/torch_ops_cpu_llvm_sync.json
+++ b/torch_ops/configs/torch_ops_cpu_llvm_sync.json
@@ -22,5 +22,6 @@
         "AB/256x256xf32_bench": 0.30,
         "AB/512x512xf32_bench": 0.88,
         "AB/1024x1024xf32_bench": 1.83
-    }
+    },
+    "tolerance_factor": 1.1
 }

--- a/torch_ops/conftest.py
+++ b/torch_ops/conftest.py
@@ -181,6 +181,7 @@ class MlirCompileRunTest(pytest.File):
             tgt_config["golden_time_ms"] = tgt_config.get("golden_times_ms", {}).get(
                 gen_config.qualified_name, float("nan")
             )
+            tgt_config["tolerance_factor"] = tgt_config.get("tolerance_factor", 1.1)
             tgt_config["use_rocprofv3"] = self.use_rocprofv3
 
             match gen_config.mode:
@@ -235,6 +236,10 @@ class IreeBaseTest(pytest.Item):
     @property
     def golden_time(self):
         return self.tgt_config["golden_time_ms"]
+
+    @property
+    def tolerance_factor(self):
+        return self.tgt_config["tolerance_factor"]
 
     def _get_golden_input(self):
         """Get golden_inputs from azure and pass the path to common config."""
@@ -310,6 +315,7 @@ class IreeBenchmarkTest(IreeBaseTest):
                 iree_compile_flags,
                 iree_run_flags,
                 golden_time_ms=self.golden_time,
+                tolerance_factor=self.tolerance_factor,
                 skip_run=skip_run,
                 use_rocprofv3=self.use_rocprofv3,
             )


### PR DESCRIPTION
Instead of having the golden_time being the product of the actual time expected and tolerance factor, split it into a tolerance factor that can be adjusted independently of the golden time.

By default, the tolerance factor is 1.1, which allows for a tolerance of 10% increase over the golden time.